### PR TITLE
Bugfix for subject mapping (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ mvn spring-boot:build-image
 Starta en Docker-container:
 
 ```
-docker run -i --rm -p 8080:8080 evil.sundsvall.se/ms-messaging:latest
+docker run -i --rm -p 8080:8080 evil.sundsvall.se/ms-messaging-v2:latest
 ```
 
 Copyright &copy; 2022 Sundsvalls kommun

--- a/src/main/java/se/sundsvall/messaging/integration/smssender/SmsSenderIntegrationMapper.java
+++ b/src/main/java/se/sundsvall/messaging/integration/smssender/SmsSenderIntegrationMapper.java
@@ -16,9 +16,9 @@ class SmsSenderIntegrationMapper {
         }
 
         return new SendSmsRequest()
-            .message(smsDto.getMessage())
-            .mobileNumber(smsDto.getMobileNumber())
             .sender(new Sender()
-                .name(smsDto.getSender().getName()));
+                .name(smsDto.getSender().getName()))
+            .mobileNumber(smsDto.getMobileNumber())
+            .message(smsDto.getMessage());
     }
 }

--- a/src/main/java/se/sundsvall/messaging/processor/MessageProcessor.java
+++ b/src/main/java/se/sundsvall/messaging/processor/MessageProcessor.java
@@ -122,6 +122,7 @@ class MessageProcessor extends Processor {
             .withHeaders(message.getHeaders())
             .withSender(sender)
             .withEmailAddress(emailAddress)
+            .withSubject(message.getSubject())
             .withMessage(message.getMessage())
             .build();
 

--- a/src/test/java/se/sundsvall/messaging/integration/emailsender/EmailProcessorTests.java
+++ b/src/test/java/se/sundsvall/messaging/integration/emailsender/EmailProcessorTests.java
@@ -22,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
+import se.sundsvall.messaging.configuration.DefaultSettings;
 import se.sundsvall.messaging.configuration.RetryProperties;
 import se.sundsvall.messaging.dto.EmailDto;
 import se.sundsvall.messaging.integration.db.HistoryRepository;
@@ -45,6 +46,8 @@ class EmailProcessorTests {
     private HistoryRepository mockHistoryRepository;
     @Mock
     private EmailSenderIntegration mockEmailSenderIntegration;
+    @Mock
+    private DefaultSettings mockDefaultSettings;
 
     private EmailProcessor emailProcessor;
 
@@ -55,7 +58,7 @@ class EmailProcessorTests {
         when(mockRetryProperties.getMaxDelay()).thenReturn(Duration.ofMillis(100));
 
         emailProcessor = new EmailProcessor(mockRetryProperties, mockMessageRepository,
-            mockHistoryRepository, mockEmailSenderIntegration);
+            mockHistoryRepository, mockEmailSenderIntegration, mockDefaultSettings);
     }
 
     @Test

--- a/src/test/java/se/sundsvall/messaging/integration/smssender/SmsProcessorTests.java
+++ b/src/test/java/se/sundsvall/messaging/integration/smssender/SmsProcessorTests.java
@@ -23,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
+import se.sundsvall.messaging.configuration.DefaultSettings;
 import se.sundsvall.messaging.configuration.RetryProperties;
 import se.sundsvall.messaging.dto.SmsDto;
 import se.sundsvall.messaging.integration.db.HistoryRepository;
@@ -46,6 +47,8 @@ class SmsProcessorTests {
     private HistoryRepository mockHistoryRepository;
     @Mock
     private SmsSenderIntegration mockSmsSenderIntegration;
+    @Mock
+    private DefaultSettings mockDefaultSettings;
 
     private SmsProcessor smsProcessor;
 
@@ -56,7 +59,7 @@ class SmsProcessorTests {
         when(mockRetryProperties.getMaxDelay()).thenReturn(Duration.ofMillis(100));
 
         smsProcessor = new SmsProcessor(mockRetryProperties, mockMessageRepository,
-            mockHistoryRepository, mockSmsSenderIntegration);
+            mockHistoryRepository, mockSmsSenderIntegration, mockDefaultSettings);
     }
 
     @Test


### PR DESCRIPTION
* Update README.md

* Fixed missing subject mapping for e-mail. Also
corrected handling of default sender for e-mails
and SMS:es.

Co-authored-by: lsjolinder <110965999+lsjolinder@users.noreply.github.com>