### PR TITLE
UF-3527 - Allow overriding digital-mail defaults

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>se.sundsvall.messaging</groupId>
     <artifactId>api-service-messaging</artifactId>
-    <version>2.3</version>
+    <version>2.4</version>
     <name>api-service-messaging</name>
 
     <properties>

--- a/src/integration-test/resources/application-it.properties
+++ b/src/integration-test/resources/application-it.properties
@@ -19,10 +19,16 @@ retry.max-attempts=3
 retry.initial-delay=500ms
 retry.max-delay=5s
 
-# Sender defaults
-messaging.default-sender.sms-name=Sender
-messaging.default-sender.email-name=Longer Sender
-messaging.default-sender.email-address=longer.sender@somehost.com
+# Defaults
+messaging.defaults.sms.name=Sender
+messaging.defaults.email.name=Longer Sender
+messaging.defaults.email.address=longer.sender@somehost.com
+messaging.defaults.digital-mail.municipality-id=someMunicipalityId
+messaging.defaults.digital-mail.subject=someSubject
+messaging.defaults.digital-mail.support-info.text=someInfoText
+messaging.defaults.digital-mail.support-info.email-address=someEmailAddress
+messaging.defaults.digital-mail.support-info.phone-number=somePhoneNumber
+messaging.defaults.digital-mail.support-info.url=someUrl
 
 # SmsSender integration
 integration.sms-sender.base-url=http://localhost:${wiremock.server.port}/sms-sender
@@ -53,14 +59,6 @@ integration.digital-mail-sender.base-url=http://localhost:${wiremock.server.port
 integration.digital-mail-sender.token-url=http://localhost:${wiremock.server.port}/token
 integration.digital-mail-sender.client-id=someClientId
 integration.digital-mail-sender.client-secret=someClientSecret
-
-# DigitalMailSender integration defaults
-integration.digital-mail-sender.defaults.municipality-id=someMunicipalityId
-integration.digital-mail-sender.defaults.subject=someSubject
-integration.digital-mail-sender.defaults.support-info.text=someInfoText
-integration.digital-mail-sender.defaults.support-info.email-address=someEmailAddress
-integration.digital-mail-sender.defaults.support-info.phone-number=somePhoneNumber
-integration.digital-mail-sender.defaults.support-info.url=someUrl
 
 # FeedbackSettings integration
 integration.feedback-settings.base-url=http://localhost:${wiremock.server.port}/feedback-settings

--- a/src/integration-test/resources/openapi.yml
+++ b/src/integration-test/resources/openapi.yml
@@ -7,13 +7,13 @@ info:
     url: https://opensource.org/licenses/MIT
   version: "2.3"
 servers:
-  - url: http://localhost:60073
-    description: Generated server url
+- url: http://localhost:8080
+  description: Generated server url
 paths:
   /webmessage:
     post:
       tags:
-        - Sending Resources
+      - Sending Resources
       summary: Send a single web message
       operationId: sendWebMessage
       requestBody:
@@ -23,15 +23,6 @@ paths:
               $ref: '#/components/schemas/WebMessageRequest'
         required: true
       responses:
-        "200":
-          description: Successful Operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MessageResponse'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/MessageResponse'
         "400":
           description: Bad Request
           content:
@@ -41,6 +32,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
         "500":
           description: Internal Server Error
           content:
@@ -53,7 +53,7 @@ paths:
   /snailmail:
     post:
       tags:
-        - Sending Resources
+      - Sending Resources
       summary: Send a single snailmail
       operationId: sendSnailmail
       requestBody:
@@ -63,15 +63,6 @@ paths:
               $ref: '#/components/schemas/SnailmailRequest'
         required: true
       responses:
-        "200":
-          description: Successful Operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MessageResponse'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/MessageResponse'
         "400":
           description: Bad Request
           content:
@@ -81,6 +72,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
         "500":
           description: Internal Server Error
           content:
@@ -93,7 +93,7 @@ paths:
   /sms:
     post:
       tags:
-        - Sending Resources
+      - Sending Resources
       summary: Send a single SMS
       operationId: sendSms
       requestBody:
@@ -103,15 +103,6 @@ paths:
               $ref: '#/components/schemas/SmsRequest'
         required: true
       responses:
-        "200":
-          description: Successful Operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MessageResponse'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/MessageResponse'
         "400":
           description: Bad Request
           content:
@@ -121,6 +112,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
         "500":
           description: Internal Server Error
           content:
@@ -133,7 +133,7 @@ paths:
   /messages:
     post:
       tags:
-        - Sending Resources
+      - Sending Resources
       summary: Send a batch of messages as e-mail or SMS to a list of parties
       operationId: sendMessages
       requestBody:
@@ -152,15 +152,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "200":
-          description: Successful Operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MessagesResponse'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/MessagesResponse'
         "500":
           description: Internal Server Error
           content:
@@ -170,10 +161,19 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessagesResponse'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/MessagesResponse'
   /email:
     post:
       tags:
-        - Sending Resources
+      - Sending Resources
       summary: Send a single e-mail
       operationId: sendEmail
       requestBody:
@@ -183,15 +183,6 @@ paths:
               $ref: '#/components/schemas/EmailRequest'
         required: true
       responses:
-        "200":
-          description: Successful Operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MessageResponse'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/MessageResponse'
         "400":
           description: Bad Request
           content:
@@ -201,6 +192,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
         "500":
           description: Internal Server Error
           content:
@@ -213,7 +213,7 @@ paths:
   /digitalmail:
     post:
       tags:
-        - Sending Resources
+      - Sending Resources
       summary: Send a single digital mail to one or more parties
       operationId: sendDigitalMail
       requestBody:
@@ -223,15 +223,6 @@ paths:
               $ref: '#/components/schemas/DigitalMailRequest'
         required: true
       responses:
-        "200":
-          description: Successful Operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MessagesResponse'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/MessagesResponse'
         "400":
           description: Bad Request
           content:
@@ -250,30 +241,30 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessagesResponse'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/MessagesResponse'
   /status/{messageId}:
     get:
       tags:
-        - Status and History Resources
+      - Status and History Resources
       summary: Get the status for a single message and its deliveries
       operationId: getMessageStatus
       parameters:
-        - name: messageId
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: messageId
+        in: path
+        required: true
+        schema:
+          type: string
       responses:
         "404":
           description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -290,21 +281,39 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageStatusResponse'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
   /message/{messageId}:
     get:
       tags:
-        - Status and History Resources
+      - Status and History Resources
       summary: Get a message and all its deliveries
       operationId: getMessage
       parameters:
-        - name: messageId
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: messageId
+        in: path
+        required: true
+        schema:
+          type: string
       responses:
         "404":
           description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -321,51 +330,33 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/HistoryResponse'
-        "500":
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
   /conversation-history/{partyId}:
     get:
       tags:
-        - Status and History Resources
+      - Status and History Resources
       summary: Get the entire conversation history for a given party
       operationId: getConversationHistory
       parameters:
-        - name: partyId
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: from
-          in: query
-          description: "From-date (inclusive). Format: yyyy-MM-dd (ISO8601)"
-          required: false
-          schema:
-            type: string
-            format: date
-        - name: to
-          in: query
-          description: "To-date (inclusive). Format: yyyy-MM-dd (ISO8601)"
-          required: false
-          schema:
-            type: string
-            format: date
+      - name: partyId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: from
+        in: query
+        description: "From-date (inclusive). Format: yyyy-MM-dd (ISO8601)"
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: to
+        in: query
+        description: "To-date (inclusive). Format: yyyy-MM-dd (ISO8601)"
+        required: false
+        schema:
+          type: string
+          format: date
       responses:
-        "200":
-          description: Successful Operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HistoryResponse'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/HistoryResponse'
         "500":
           description: Internal Server Error
           content:
@@ -375,18 +366,27 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HistoryResponse'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/HistoryResponse'
   /batch-status/{batchId}:
     get:
       tags:
-        - Status and History Resources
+      - Status and History Resources
       summary: "Get the status for a message batch, its messages and their deliveries"
       operationId: getBatchStatus
       parameters:
-        - name: batchId
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: batchId
+        in: path
+        required: true
+        schema:
+          type: string
       responses:
         "404":
           description: Not Found
@@ -397,15 +397,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "200":
-          description: Successful Operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BatchStatusResponse'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/BatchStatusResponse'
         "500":
           description: Internal Server Error
           content:
@@ -415,10 +406,19 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchStatusResponse'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BatchStatusResponse'
   /api-docs:
     get:
       tags:
-        - API
+      - API
       summary: OpenAPI
       operationId: getApiDocs
       responses:
@@ -435,8 +435,8 @@ components:
   schemas:
     ExternalReference:
       required:
-        - key
-        - value
+      - key
+      - value
       type: object
       properties:
         key:
@@ -450,17 +450,17 @@ components:
       description: External references
     Header:
       required:
-        - values
+      - values
       type: object
       properties:
         name:
           type: string
           description: The header name
           enum:
-            - DISTRIBUTION_RULE
-            - CATEGORY
-            - FACILITY_ID
-            - TYPE
+          - DISTRIBUTION_RULE
+          - CATEGORY
+          - FACILITY_ID
+          - TYPE
         values:
           type: array
           description: The header values
@@ -496,7 +496,7 @@ components:
       description: Attachment
     WebMessageRequest:
       required:
-        - message
+      - message
       type: object
       properties:
         party:
@@ -514,11 +514,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/WebMessageAttachment'
-    MessageResponse:
-      type: object
-      properties:
-        messageId:
-          type: string
     Problem:
       type: object
       properties:
@@ -534,22 +529,27 @@ components:
             type: object
         status:
           $ref: '#/components/schemas/StatusType'
-        title:
-          type: string
         detail:
+          type: string
+        title:
           type: string
     StatusType:
       type: object
       properties:
+        reasonPhrase:
+          type: string
         statusCode:
           type: integer
           format: int32
-        reasonPhrase:
+    MessageResponse:
+      type: object
+      properties:
+        messageId:
           type: string
     SnailmailAttachment:
       required:
-        - content
-        - name
+      - content
+      - name
       type: object
       properties:
         content:
@@ -567,8 +567,8 @@ components:
       description: Attachment
     SnailmailRequest:
       required:
-        - department
-        - personId
+      - department
+      - personId
       type: object
       properties:
         party:
@@ -595,7 +595,7 @@ components:
             $ref: '#/components/schemas/SnailmailAttachment'
     Sms:
       required:
-        - name
+      - name
       type: object
       properties:
         name:
@@ -607,8 +607,8 @@ components:
       description: Sender
     SmsRequest:
       required:
-        - message
-        - mobileNumber
+      - message
+      - mobileNumber
       type: object
       properties:
         party:
@@ -626,10 +626,20 @@ components:
         message:
           type: string
           description: Message
+    DigitalMail:
+      required:
+      - municipalityId
+      - supportInfo
+      type: object
+      properties:
+        municipalityId:
+          type: string
+        supportInfo:
+          $ref: '#/components/schemas/SupportInfo'
     Email:
       required:
-        - address
-        - name
+      - address
+      - name
       type: object
       properties:
         name:
@@ -645,7 +655,7 @@ components:
           example: sender@sender.se
     Message:
       required:
-        - message
+      - message
       type: object
       properties:
         party:
@@ -683,7 +693,25 @@ components:
           $ref: '#/components/schemas/Sms'
         email:
           $ref: '#/components/schemas/Email'
+        digitalMail:
+          $ref: '#/components/schemas/DigitalMail'
       description: Sender
+    SupportInfo:
+      required:
+      - emailAddress
+      - phoneNumber
+      - text
+      - url
+      type: object
+      properties:
+        text:
+          type: string
+        emailAddress:
+          type: string
+        phoneNumber:
+          type: string
+        url:
+          type: string
     MessagesResponse:
       type: object
       properties:
@@ -695,8 +723,8 @@ components:
             type: string
     EmailAttachment:
       required:
-        - content
-        - name
+      - content
+      - name
       type: object
       properties:
         content:
@@ -714,8 +742,8 @@ components:
       description: Attachment
     EmailRequest:
       required:
-        - emailAddress
-        - subject
+      - emailAddress
+      - subject
       type: object
       properties:
         party:
@@ -745,15 +773,15 @@ components:
             $ref: '#/components/schemas/EmailAttachment'
     DigitalMailAttachment:
       required:
-        - content
-        - filename
+      - content
+      - filename
       type: object
       properties:
         contentType:
           type: string
           description: Content type
           enum:
-            - application/pdf
+          - application/pdf
         content:
           type: string
           description: Content (BASE64-encoded)
@@ -763,8 +791,8 @@ components:
       description: Attachments
     DigitalMailRequest:
       required:
-        - body
-        - contentType
+      - body
+      - contentType
       type: object
       properties:
         party:
@@ -774,6 +802,8 @@ components:
           description: Headers
           items:
             $ref: '#/components/schemas/Header'
+        sender:
+          $ref: '#/components/schemas/DigitalMail'
         subject:
           type: string
           description: Subject
@@ -782,8 +812,8 @@ components:
           type: string
           description: Content type
           enum:
-            - text/plain
-            - text/html
+          - text/plain
+          - text/html
         body:
           type: string
           description: Body (BASE64-encoded)
@@ -794,7 +824,7 @@ components:
             $ref: '#/components/schemas/DigitalMailAttachment'
     Parties:
       required:
-        - partyIds
+      - partyIds
       type: object
       properties:
         partyIds:
@@ -819,12 +849,12 @@ components:
         status:
           type: string
           enum:
-            - AWAITING_FEEDBACK
-            - PENDING
-            - SENT
-            - FAILED
-            - NO_FEEDBACK_SETTINGS_FOUND
-            - NO_FEEDBACK_WANTED
+          - AWAITING_FEEDBACK
+          - PENDING
+          - SENT
+          - FAILED
+          - NO_FEEDBACK_SETTINGS_FOUND
+          - NO_FEEDBACK_WANTED
     HistoryResponse:
       type: object
       properties:
@@ -833,21 +863,21 @@ components:
         messageType:
           type: string
           enum:
-            - MESSAGE
-            - EMAIL
-            - SMS
-            - WEB_MESSAGE
-            - DIGITAL_MAIL
-            - SNAIL_MAIL
+          - MESSAGE
+          - EMAIL
+          - SMS
+          - WEB_MESSAGE
+          - DIGITAL_MAIL
+          - SNAIL_MAIL
         status:
           type: string
           enum:
-            - AWAITING_FEEDBACK
-            - PENDING
-            - SENT
-            - FAILED
-            - NO_FEEDBACK_SETTINGS_FOUND
-            - NO_FEEDBACK_WANTED
+          - AWAITING_FEEDBACK
+          - PENDING
+          - SENT
+          - FAILED
+          - NO_FEEDBACK_SETTINGS_FOUND
+          - NO_FEEDBACK_WANTED
         timestamp:
           type: string
           format: date-time

--- a/src/integration-test/resources/openapi.yml
+++ b/src/integration-test/resources/openapi.yml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT License
     url: https://opensource.org/licenses/MIT
-  version: "2.3"
+  version: "2.4"
 servers:
 - url: http://localhost:8080
   description: Generated server url
@@ -23,15 +23,6 @@ paths:
               $ref: '#/components/schemas/WebMessageRequest'
         required: true
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
         "200":
           description: Successful Operation
           content:
@@ -41,6 +32,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         "500":
           description: Internal Server Error
           content:
@@ -63,15 +63,6 @@ paths:
               $ref: '#/components/schemas/SnailmailRequest'
         required: true
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
         "200":
           description: Successful Operation
           content:
@@ -81,6 +72,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         "500":
           description: Internal Server Error
           content:
@@ -103,15 +103,6 @@ paths:
               $ref: '#/components/schemas/SmsRequest'
         required: true
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
         "200":
           description: Successful Operation
           content:
@@ -121,6 +112,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         "500":
           description: Internal Server Error
           content:
@@ -143,6 +143,15 @@ paths:
               $ref: '#/components/schemas/MessageRequest'
         required: true
       responses:
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessagesResponse'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/MessagesResponse'
         "400":
           description: Bad Request
           content:
@@ -161,15 +170,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "200":
-          description: Successful Operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MessagesResponse'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/MessagesResponse'
   /email:
     post:
       tags:
@@ -183,15 +183,6 @@ paths:
               $ref: '#/components/schemas/EmailRequest'
         required: true
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
         "200":
           description: Successful Operation
           content:
@@ -201,6 +192,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         "500":
           description: Internal Server Error
           content:
@@ -223,6 +223,15 @@ paths:
               $ref: '#/components/schemas/DigitalMailRequest'
         required: true
       responses:
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessagesResponse'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/MessagesResponse'
         "400":
           description: Bad Request
           content:
@@ -241,15 +250,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "200":
-          description: Successful Operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MessagesResponse'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/MessagesResponse'
   /status/{messageId}:
     get:
       tags:
@@ -303,6 +303,15 @@ paths:
         schema:
           type: string
       responses:
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HistoryResponse'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/HistoryResponse'
         "404":
           description: Not Found
           content:
@@ -321,15 +330,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "200":
-          description: Successful Operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HistoryResponse'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/HistoryResponse'
   /conversation-history/{partyId}:
     get:
       tags:
@@ -357,15 +357,6 @@ paths:
           type: string
           format: date
       responses:
-        "500":
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
         "200":
           description: Successful Operation
           content:
@@ -375,6 +366,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/HistoryResponse'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
   /batch-status/{batchId}:
     get:
       tags:
@@ -397,15 +397,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
         "200":
           description: Successful Operation
           content:
@@ -415,6 +406,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/BatchStatusResponse'
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
   /api-docs:
     get:
       tags:
@@ -514,6 +514,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/WebMessageAttachment'
+    MessageResponse:
+      type: object
+      properties:
+        messageId:
+          type: string
     Problem:
       type: object
       properties:
@@ -529,22 +534,17 @@ components:
             type: object
         status:
           $ref: '#/components/schemas/StatusType'
-        detail:
-          type: string
         title:
+          type: string
+        detail:
           type: string
     StatusType:
       type: object
       properties:
-        reasonPhrase:
-          type: string
         statusCode:
           type: integer
           format: int32
-    MessageResponse:
-      type: object
-      properties:
-        messageId:
+        reasonPhrase:
           type: string
     SnailmailAttachment:
       required:
@@ -628,12 +628,9 @@ components:
           description: Message
     DigitalMail:
       required:
-      - municipalityId
       - supportInfo
       type: object
       properties:
-        municipalityId:
-          type: string
         supportInfo:
           $ref: '#/components/schemas/SupportInfo'
     Email:

--- a/src/main/java/se/sundsvall/messaging/api/model/DigitalMailRequest.java
+++ b/src/main/java/se/sundsvall/messaging/api/model/DigitalMailRequest.java
@@ -6,6 +6,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 
 import se.sundsvall.messaging.api.model.validation.OneOf;
+import se.sundsvall.messaging.model.Sender;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
@@ -22,6 +23,10 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class DigitalMailRequest extends BatchRequest {
+
+    @Valid
+    @Schema(description = "Sender")
+    private Sender.DigitalMail sender;
 
     @Schema(description = "Subject", nullable = true)
     private String subject;

--- a/src/main/java/se/sundsvall/messaging/configuration/Defaults.java
+++ b/src/main/java/se/sundsvall/messaging/configuration/Defaults.java
@@ -1,6 +1,7 @@
 package se.sundsvall.messaging.configuration;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -12,8 +13,8 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@ConfigurationProperties(prefix = "messaging.default-sender")
-public class DefaultSettings {
+@ConfigurationProperties(prefix = "messaging.defaults")
+public class Defaults {
 
     @Valid
     @NotNull
@@ -22,4 +23,16 @@ public class DefaultSettings {
     @Valid
     @NotNull
     private Sender.Email email;
+
+    @Valid
+    @NotNull
+    private DigitalMail digitalMail;
+
+    @Getter
+    @Setter
+    public static class DigitalMail extends Sender.DigitalMail {
+
+        @NotBlank
+        private String subject;
+    }
 }

--- a/src/main/java/se/sundsvall/messaging/configuration/DefaultsConfiguration.java
+++ b/src/main/java/se/sundsvall/messaging/configuration/DefaultsConfiguration.java
@@ -4,7 +4,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties(DefaultSettings.class)
-class DefaultSettingsConfiguration {
+@EnableConfigurationProperties(Defaults.class)
+class DefaultsConfiguration {
 
 }

--- a/src/main/java/se/sundsvall/messaging/dto/DigitalMailDto.java
+++ b/src/main/java/se/sundsvall/messaging/dto/DigitalMailDto.java
@@ -3,6 +3,7 @@ package se.sundsvall.messaging.dto;
 import java.util.List;
 
 import se.sundsvall.messaging.model.ContentType;
+import se.sundsvall.messaging.model.Sender;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -14,6 +15,7 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class DigitalMailDto {
 
+    private final Sender.DigitalMail sender;
     private final String partyId;
     private final String subject;
     private final ContentType contentType;

--- a/src/main/java/se/sundsvall/messaging/integration/digitalmailsender/DigitalMailProcessor.java
+++ b/src/main/java/se/sundsvall/messaging/integration/digitalmailsender/DigitalMailProcessor.java
@@ -78,9 +78,11 @@ class DigitalMailProcessor extends Processor {
     DigitalMailDto mapToDto(final MessageEntity message) {
         var request = GSON.fromJson(message.getContent(), DigitalMailRequest.class);
 
-        // Use sender from thr original request, or use default sender as fallback
+        // Use sender from the original request, or use default sender as fallback
         var sender = Optional.ofNullable(request.getSender()).orElseGet(defaults::getDigitalMail);
-        // Use subject from thr original request, or use default subject as fallback
+        // Always use the municipality id from the defaults
+        sender.setMunicipalityId(defaults.getDigitalMail().getMunicipalityId());
+        // Use subject from the original request, or use default subject as fallback
         var subject = Optional.ofNullable(request.getSubject())
             .orElseGet(() -> defaults.getDigitalMail().getSubject());
 

--- a/src/main/java/se/sundsvall/messaging/integration/digitalmailsender/DigitalMailSenderIntegrationConfiguration.java
+++ b/src/main/java/se/sundsvall/messaging/integration/digitalmailsender/DigitalMailSenderIntegrationConfiguration.java
@@ -1,5 +1,7 @@
 package se.sundsvall.messaging.integration.digitalmailsender;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import org.springframework.cloud.openfeign.FeignBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -7,11 +9,10 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 
 import se.sundsvall.dept44.configuration.feign.FeignConfiguration;
-import se.sundsvall.dept44.configuration.feign.FeignHelper;
+import se.sundsvall.dept44.configuration.feign.FeignMultiCustomizer;
 import se.sundsvall.dept44.configuration.feign.decoder.ProblemErrorDecoder;
 
-import feign.RequestInterceptor;
-import feign.codec.ErrorDecoder;
+import feign.Request;
 
 @Import(FeignConfiguration.class)
 class DigitalMailSenderIntegrationConfiguration {
@@ -23,26 +24,29 @@ class DigitalMailSenderIntegrationConfiguration {
     }
 
     @Bean
-    RequestInterceptor oAuth2RequestInterceptor() {
-        return FeignHelper.oAuth2RequestInterceptor(ClientRegistration
+    FeignBuilderCustomizer feignCustomizer() {
+        return FeignMultiCustomizer.create()
+            .withRetryableOAuth2InterceptorForClientRegistration(clientRegistration())
+            .withRequestOptions(requestOptions())
+            .withErrorDecoder(new ProblemErrorDecoder(DigitalMailSenderIntegration.INTEGRATION_NAME))
+            .composeCustomizersToOne();
+    }
+
+    private ClientRegistration clientRegistration() {
+        return ClientRegistration
             .withRegistrationId(DigitalMailSenderIntegration.INTEGRATION_NAME)
             .tokenUri(properties.getTokenUrl())
             .clientId(properties.getClientId())
             .clientSecret(properties.getClientSecret())
             .authorizationGrantType(new AuthorizationGrantType(properties.getGrantType()))
-            .build());
-    }
-
-    @Bean
-    FeignBuilderCustomizer customizer() {
-        return FeignHelper.customizeRequestOptions()
-            .withConnectTimeout(properties.getConnectTimeout())
-            .withReadTimeout(properties.getReadTimeout())
             .build();
     }
 
-    @Bean
-    ErrorDecoder errorDecoder() {
-        return new ProblemErrorDecoder(DigitalMailSenderIntegration.INTEGRATION_NAME);
+    private Request.Options requestOptions() {
+        return new Request.Options(
+            properties.getConnectTimeout().toMillis(), MILLISECONDS,
+            properties.getReadTimeout().toMillis(), MILLISECONDS,
+            true
+        );
     }
 }

--- a/src/main/java/se/sundsvall/messaging/integration/digitalmailsender/DigitalMailSenderIntegrationMapper.java
+++ b/src/main/java/se/sundsvall/messaging/integration/digitalmailsender/DigitalMailSenderIntegrationMapper.java
@@ -1,11 +1,8 @@
 package se.sundsvall.messaging.integration.digitalmailsender;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
-import org.springframework.util.CollectionUtils;
 
 import se.sundsvall.messaging.dto.DigitalMailDto;
 
@@ -17,40 +14,32 @@ import generated.se.sundsvall.digitalmailsender.SupportInfo;
 @Component
 class DigitalMailSenderIntegrationMapper {
 
-    private final DigitalMailSenderIntegrationProperties properties;
-
-    DigitalMailSenderIntegrationMapper(final DigitalMailSenderIntegrationProperties properties) {
-        this.properties = properties;
-    }
-
     DigitalMailRequest toDigitalMailRequest(final DigitalMailDto dto) {
         if (dto == null) {
             return null;
         }
 
-        List<Attachment> attachments = null;
-        if (!CollectionUtils.isEmpty(dto.getAttachments())) {
-            attachments = Optional.ofNullable(dto.getAttachments()).stream()
-                    .flatMap(Collection::stream)
-                    .map(attachment -> new Attachment()
-                            .contentType(attachment.getContentType().getValue())
-                            .body(attachment.getContent())
-                            .filename(attachment.getFilename()))
-                    .toList();
-        }
+        var attachments = Optional.ofNullable(dto.getAttachments())
+            .map(dtoAttachments -> dtoAttachments.stream()
+                .map(attachment -> new Attachment()
+                    .contentType(attachment.getContentType().getValue())
+                    .body(attachment.getContent())
+                    .filename(attachment.getFilename()))
+                .toList())
+            .orElse(null);
 
         return new DigitalMailRequest()
-                .partyId(dto.getPartyId())
-                .municipalityId(properties.getDefaults().getMunicipalityId())
-                .headerSubject(Optional.ofNullable(dto.getSubject()).orElse(properties.getDefaults().getSubject()))
-                .supportInfo(new SupportInfo()
-                        .supportText(properties.getDefaults().getSupportInfo().getText())
-                        .contactInformationEmail(properties.getDefaults().getSupportInfo().getEmailAddress())
-                        .contactInformationPhoneNumber(properties.getDefaults().getSupportInfo().getPhoneNumber())
-                        .contactInformationUrl(properties.getDefaults().getSupportInfo().getUrl()))
-                .bodyInformation(new BodyInformation()
-                        .contentType(dto.getContentType().getValue())
-                        .body(dto.getBody()))
-                .attachments(attachments);
+            .partyId(dto.getPartyId())
+            .municipalityId(dto.getSender().getMunicipalityId())
+            .headerSubject(dto.getSubject())
+            .supportInfo(new SupportInfo()
+                .supportText(dto.getSender().getSupportInfo().getText())
+                .contactInformationEmail(dto.getSender().getSupportInfo().getEmailAddress())
+                .contactInformationPhoneNumber(dto.getSender().getSupportInfo().getPhoneNumber())
+                .contactInformationUrl(dto.getSender().getSupportInfo().getUrl()))
+            .bodyInformation(new BodyInformation()
+                .contentType(dto.getContentType().getValue())
+                .body(dto.getBody()))
+            .attachments(attachments);
     }
 }

--- a/src/main/java/se/sundsvall/messaging/integration/digitalmailsender/DigitalMailSenderIntegrationProperties.java
+++ b/src/main/java/se/sundsvall/messaging/integration/digitalmailsender/DigitalMailSenderIntegrationProperties.java
@@ -2,11 +2,6 @@ package se.sundsvall.messaging.integration.digitalmailsender;
 
 import java.time.Duration;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import se.sundsvall.messaging.integration.AbstractRestIntegrationProperties;
@@ -21,42 +16,4 @@ public class DigitalMailSenderIntegrationProperties extends AbstractRestIntegrat
 
     private Duration pollDelay = Duration.ofSeconds(5);
     private int maxRetries = 3;
-
-    @Valid
-    @NotNull
-    private Defaults defaults;
-
-    @Getter
-    @Setter
-    public static class Defaults {
-
-        @NotBlank
-        private String municipalityId;
-
-        @NotBlank
-        private String subject;
-
-        @Valid
-        @NotNull
-        private SupportInfo supportInfo;
-
-        @Getter
-        @Setter
-        public static class SupportInfo {
-
-            @NotBlank
-            private String text;
-
-            @Email
-            @NotBlank
-            private String emailAddress;
-
-            @NotBlank
-            private String phoneNumber;
-
-            @NotBlank
-            private String url;
-        }
-
-    }
 }

--- a/src/main/java/se/sundsvall/messaging/integration/webmessagesender/WebMessageProcessor.java
+++ b/src/main/java/se/sundsvall/messaging/integration/webmessagesender/WebMessageProcessor.java
@@ -1,7 +1,5 @@
 package se.sundsvall.messaging.integration.webmessagesender;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.context.event.EventListener;
@@ -29,8 +27,7 @@ class WebMessageProcessor extends Processor {
 
     private final RetryPolicy<ResponseEntity<Void>> retryPolicy;
 
-    WebMessageProcessor(final RetryProperties retryProperties,
-            final MessageRepository messageRepository,
+    WebMessageProcessor(final RetryProperties retryProperties, final MessageRepository messageRepository,
             final HistoryRepository historyRepository,
             final WebMessageSenderIntegration webMessageSenderIntegration) {
         super(messageRepository, historyRepository);
@@ -74,17 +71,15 @@ class WebMessageProcessor extends Processor {
     WebMessageDto mapToDto(final MessageEntity message) {
         var request = GSON.fromJson(message.getContent(), WebMessageRequest.class);
 
-        List<WebMessageDto.AttachmentDto> attachments = null;
-        if (request.getAttachments() != null) {
-            attachments = Optional.of(request.getAttachments()).stream()
-                    .flatMap(Collection::stream)
-                    .map(attachment -> WebMessageDto.AttachmentDto.builder()
-                            .withFileName(attachment.getFileName())
-                            .withMimeType(attachment.getMimeType())
-                            .withBase64Data(attachment.getBase64Data())
-                            .build())
-                    .toList();
-        }
+        var attachments = Optional.ofNullable(request.getAttachments())
+            .map(requestAttachments -> requestAttachments.stream()
+                .map(attachment -> WebMessageDto.AttachmentDto.builder()
+                    .withFileName(attachment.getFileName())
+                    .withMimeType(attachment.getMimeType())
+                    .withBase64Data(attachment.getBase64Data())
+                    .build())
+                .toList())
+            .orElse(null);
 
         return WebMessageDto.builder()
                 .withParty(request.getParty())

--- a/src/main/java/se/sundsvall/messaging/model/Sender.java
+++ b/src/main/java/se/sundsvall/messaging/model/Sender.java
@@ -5,6 +5,8 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -76,6 +78,7 @@ public class Sender {
     public static class DigitalMail {
 
         @NotBlank
+        @JsonIgnore // Since this shouldn't be possible to set in requests
         private String municipalityId;
 
         @Valid

--- a/src/main/java/se/sundsvall/messaging/model/Sender.java
+++ b/src/main/java/se/sundsvall/messaging/model/Sender.java
@@ -2,6 +2,7 @@ package se.sundsvall.messaging.model;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -26,6 +27,9 @@ public class Sender {
 
     @Valid
     private Sender.Email email;
+
+    @Valid
+    private Sender.DigitalMail digitalMail;
 
     @Getter
     @Setter
@@ -61,5 +65,43 @@ public class Sender {
         @Schema(description = "Reply-to e-mail address", example = "sender@sender.se")
         @javax.validation.constraints.Email
         private String replyTo;
+    }
+
+    @Getter
+    @Setter
+    @EqualsAndHashCode
+    @NoArgsConstructor
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @Builder(setterPrefix = "with")
+    public static class DigitalMail {
+
+        @NotBlank
+        private String municipalityId;
+
+        @Valid
+        @NotNull
+        private SupportInfo supportInfo;
+
+        @Getter
+        @Setter
+        @EqualsAndHashCode
+        @NoArgsConstructor
+        @AllArgsConstructor(access = AccessLevel.PRIVATE)
+        @Builder(setterPrefix = "with")
+        public static class SupportInfo {
+
+            @NotBlank
+            private String text;
+
+            @javax.validation.constraints.Email
+            @NotBlank
+            private String emailAddress;
+
+            @NotBlank
+            private String phoneNumber;
+
+            @NotBlank
+            private String url;
+        }
     }
 }

--- a/src/main/java/se/sundsvall/messaging/processor/MessageProcessor.java
+++ b/src/main/java/se/sundsvall/messaging/processor/MessageProcessor.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import se.sundsvall.messaging.api.model.EmailRequest;
 import se.sundsvall.messaging.api.model.MessageRequest;
 import se.sundsvall.messaging.api.model.SmsRequest;
-import se.sundsvall.messaging.configuration.DefaultSettings;
+import se.sundsvall.messaging.configuration.Defaults;
 import se.sundsvall.messaging.integration.db.HistoryRepository;
 import se.sundsvall.messaging.integration.db.MessageRepository;
 import se.sundsvall.messaging.integration.db.entity.MessageEntity;
@@ -36,18 +36,18 @@ class MessageProcessor extends Processor {
     private static final Gson GSON = new GsonBuilder().create();
 
     private final ApplicationEventPublisher eventPublisher;
-    private final DefaultSettings defaultSettings;
+    private final Defaults defaults;
     private final FeedbackSettingsIntegration feedbackSettingsIntegration;
 
     MessageProcessor(final ApplicationEventPublisher eventPublisher,
             final MessageRepository messageRepository,
             final HistoryRepository historyRepository,
-            final DefaultSettings defaultSettings,
+            final Defaults defaults,
             final FeedbackSettingsIntegration feedbackSettingsIntegration) {
         super(messageRepository, historyRepository);
 
         this.eventPublisher = eventPublisher;
-        this.defaultSettings = defaultSettings;
+        this.defaults = defaults;
         this.feedbackSettingsIntegration = feedbackSettingsIntegration;
     }
 
@@ -144,7 +144,7 @@ class MessageProcessor extends Processor {
 
         var sender = Optional.ofNullable(message.getSender())
             .map(Sender::getEmail)
-            .orElse(defaultSettings.getEmail());
+            .orElse(defaults.getEmail());
 
         var emailRequest = EmailRequest.builder()
             .withParty(message.getParty())
@@ -164,7 +164,7 @@ class MessageProcessor extends Processor {
 
         var sender = Optional.ofNullable(message.getSender())
             .map(Sender::getSms)
-            .orElse(defaultSettings.getSms());
+            .orElse(defaults.getSms());
 
         var smsRequest = SmsRequest.builder()
             .withParty(message.getParty())

--- a/src/main/resources/application-default.properties
+++ b/src/main/resources/application-default.properties
@@ -12,10 +12,16 @@ retry.max-attempts=3
 retry.initial-delay=1s
 retry.max-delay=20s
 
-# Sender defaults
-messaging.default-sender.sms.name=${env.DEFAULT_SENDER_SMS_NAME}
-messaging.default-sender.email.name=${env.DEFAULT_SENDER_EMAIL_NAME}
-messaging.default-sender.email.address=${env.DEFAULT_SENDER_EMAIL_ADDRESS}
+# Defaults
+messaging.defaults.sms.name=${env.DEFAULT_SENDER_SMS_NAME}
+messaging.defaults.email.name=${env.DEFAULT_SENDER_EMAIL_NAME}
+messaging.defaults.email.address=${env.DEFAULT_SENDER_EMAIL_ADDRESS}
+messaging.defaults.digital-mail.municipality-id=${env.DIGITAL_MAIL_SENDER_DEFAULT_MUNICIPALITY_ID}
+messaging.defaults.digital-mail.subject=${env.DIGITAL_MAIL_SENDER_DEFAULT_SUBJECT}
+messaging.defaults.digital-mail.support-info.text=${env.DIGITAL_MAIL_SENDER_DEFAULT_SUPPORT_INFO_TEXT}
+messaging.defaults.digital-mail.support-info.email-address=${env.DIGITAL_MAIL_SENDER_DEFAULT_SUPPORT_INFO_EMAIL_ADDRESS}
+messaging.defaults.digital-mail.support-info.phone-number=${env.DIGITAL_MAIL_SENDER_DEFAULT_SUPPORT_INFO_PHONE_NUMBER}
+messaging.defaults.digital-mail.support-info.url=${env.DIGITAL_MAIL_SENDER_DEFAULT_SUPPORT_INFO_URL}
 
 # SmsSender integration
 integration.sms-sender.base-url=${env.SMS_SENDER_INTEGRATION_BASE_URL}
@@ -40,14 +46,6 @@ integration.digital-mail-sender.base-url=${env.DIGITAL_MAIL_SENDER_INTEGRATION_B
 integration.digital-mail-sender.token-url=${env.DIGITAL_MAIL_SENDER_INTEGRATION_TOKEN_URL}
 integration.digital-mail-sender.client-id=${env.DIGITAL_MAIL_SENDER_INTEGRATION_CLIENT_ID}
 integration.digital-mail-sender.client-secret=${env.DIGITAL_MAIL_SENDER_INTEGRATION_CLIENT_SECRET}
-
-# DigitalMailSender integration defaults
-integration.digital-mail-sender.defaults.municipality-id=${env.DIGITAL_MAIL_SENDER_DEFAULT_MUNICIPALITY_ID}
-integration.digital-mail-sender.defaults.subject=${env.DIGITAL_MAIL_SENDER_DEFAULT_SUBJECT}
-integration.digital-mail-sender.defaults.support-info.text=${env.DIGITAL_MAIL_SENDER_DEFAULT_SUPPORT_INFO_TEXT}
-integration.digital-mail-sender.defaults.support-info.email-address=${env.DIGITAL_MAIL_SENDER_DEFAULT_SUPPORT_INFO_EMAIL_ADDRESS}
-integration.digital-mail-sender.defaults.support-info.phone-number=${env.DIGITAL_MAIL_SENDER_DEFAULT_SUPPORT_INFO_PHONE_NUMBER}
-integration.digital-mail-sender.defaults.support-info.url=${env.DIGITAL_MAIL_SENDER_DEFAULT_SUPPORT_INFO_URL}
 
 # SnailmailSender integration
 integration.snailmail-sender.base-url=${env.SNAILMAIL_SENDER_INTEGRATION_BASE_URL}

--- a/src/test/java/se/sundsvall/messaging/integration/digitalmailsender/DigitalMailProcessorTests.java
+++ b/src/test/java/se/sundsvall/messaging/integration/digitalmailsender/DigitalMailProcessorTests.java
@@ -84,6 +84,9 @@ class DigitalMailProcessorTests {
         var digitalMailRequest = createDigitalMailRequest();
         var messageAndDeliveryId = UUID.randomUUID().toString();
 
+        when(mockDefaults.getDigitalMail()).thenReturn(mockDefaultsDigitalMailSettings);
+        when(mockDefaultsDigitalMailSettings.getMunicipalityId()).thenReturn("someMunicipalityId");
+
         when(mockMessageRepository.findByDeliveryId(eq(messageAndDeliveryId))).thenReturn(Optional.of(
             MessageEntity.builder()
                 .withMessageId(messageAndDeliveryId)
@@ -108,6 +111,9 @@ class DigitalMailProcessorTests {
         var digitalMailRequest = createDigitalMailRequest();
         var messageAndDeliveryId = UUID.randomUUID().toString();
 
+        when(mockDefaults.getDigitalMail()).thenReturn(mockDefaultsDigitalMailSettings);
+        when(mockDefaultsDigitalMailSettings.getMunicipalityId()).thenReturn("someMunicipalityId");
+
         when(mockMessageRepository.findByDeliveryId(eq(messageAndDeliveryId))).thenReturn(Optional.of(
             MessageEntity.builder()
                 .withMessageId(messageAndDeliveryId)
@@ -131,6 +137,9 @@ class DigitalMailProcessorTests {
     void testHandleIncomingDigitalMailEvent_whenDigitalMailSenderIntegrationReturnsOtherThanOk() {
         var digitalMailRequest = createDigitalMailRequest();
         var messageAndDeliveryId = UUID.randomUUID().toString();
+
+        when(mockDefaults.getDigitalMail()).thenReturn(mockDefaultsDigitalMailSettings);
+        when(mockDefaultsDigitalMailSettings.getMunicipalityId()).thenReturn("someMunicipalityId");
 
         when(mockMessageRepository.findByDeliveryId(eq(messageAndDeliveryId))).thenReturn(Optional.of(
             MessageEntity.builder()
@@ -157,6 +166,9 @@ class DigitalMailProcessorTests {
         var digitalMailRequest = createDigitalMailRequest();
         var messageAndDeliveryId = UUID.randomUUID().toString();
 
+        when(mockDefaults.getDigitalMail()).thenReturn(mockDefaultsDigitalMailSettings);
+        when(mockDefaultsDigitalMailSettings.getMunicipalityId()).thenReturn("someMunicipalityId");
+
         when(mockMessageRepository.findByDeliveryId(eq(messageAndDeliveryId))).thenReturn(Optional.of(
             MessageEntity.builder()
                 .withMessageId(messageAndDeliveryId)
@@ -178,6 +190,9 @@ class DigitalMailProcessorTests {
 
     @Test
     void test_mapToDto() {
+        when(mockDefaults.getDigitalMail()).thenReturn(mockDefaultsDigitalMailSettings);
+        when(mockDefaultsDigitalMailSettings.getMunicipalityId()).thenReturn("someMunicipalityId");
+
         var digitalMailRequest = createDigitalMailRequest();
 
         var message = MessageEntity.builder()

--- a/src/test/java/se/sundsvall/messaging/integration/digitalmailsender/DigitalMailProcessorTests.java
+++ b/src/test/java/se/sundsvall/messaging/integration/digitalmailsender/DigitalMailProcessorTests.java
@@ -22,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
+import se.sundsvall.messaging.configuration.Defaults;
 import se.sundsvall.messaging.configuration.RetryProperties;
 import se.sundsvall.messaging.dto.DigitalMailDto;
 import se.sundsvall.messaging.integration.db.HistoryRepository;
@@ -46,6 +47,12 @@ class DigitalMailProcessorTests {
     private HistoryRepository mockHistoryRepository;
     @Mock
     private DigitalMailSenderIntegration mockDigitalMailSenderIntegration;
+    @Mock
+    private Defaults mockDefaults;
+    @Mock
+    private Defaults.DigitalMail mockDefaultsDigitalMailSettings;
+    @Mock
+    private Defaults.DigitalMail.SupportInfo mockDefaultsDigitalMailSettingsSupportInfo;
 
     private DigitalMailProcessor digitalMailProcessor;
 
@@ -56,7 +63,8 @@ class DigitalMailProcessorTests {
         when(mockRetryProperties.getMaxDelay()).thenReturn(Duration.ofMillis(100));
 
         digitalMailProcessor = new DigitalMailProcessor(mockRetryProperties,
-            mockMessageRepository, mockHistoryRepository, mockDigitalMailSenderIntegration);
+            mockMessageRepository, mockHistoryRepository, mockDigitalMailSenderIntegration,
+            mockDefaults);
     }
 
     @Test
@@ -187,5 +195,66 @@ class DigitalMailProcessorTests {
         assertThat(dto.getContentType()).isEqualTo(ContentType.fromString(digitalMailRequest.getContentType()));
         assertThat(dto.getBody()).isEqualTo(digitalMailRequest.getBody());
         assertThat(dto.getAttachments()).hasSameSizeAs(digitalMailRequest.getAttachments());
+    }
+
+    @Test
+    void test_mapToDto_whenSenderIsMissing() {
+        when(mockDefaults.getDigitalMail()).thenReturn(mockDefaultsDigitalMailSettings);
+        when(mockDefaultsDigitalMailSettings.getMunicipalityId()).thenReturn("someDefaultMunicipalityId");
+        when(mockDefaultsDigitalMailSettings.getSupportInfo()).thenReturn(mockDefaultsDigitalMailSettingsSupportInfo);
+        when(mockDefaultsDigitalMailSettingsSupportInfo.getText()).thenReturn("someDefaultSupportInfoText");
+        when(mockDefaultsDigitalMailSettingsSupportInfo.getUrl()).thenReturn("someDefaultSupportInfoUrl");
+        when(mockDefaultsDigitalMailSettingsSupportInfo.getEmailAddress()).thenReturn("someDefaultSupportInfoEmailAddress");
+        when(mockDefaultsDigitalMailSettingsSupportInfo.getPhoneNumber()).thenReturn("someDefaultSupportInfoPhoneNumber");
+
+        var request = createDigitalMailRequest();
+
+        var message = MessageEntity.builder()
+            .withMessageId(UUID.randomUUID().toString())
+            .withPartyId(request.getParty().getPartyIds().get(0))
+            .withType(MessageType.DIGITAL_MAIL)
+            .withStatus(MessageStatus.PENDING)
+            .withContent(GSON.toJson(request))
+            .build();
+        var dto = digitalMailProcessor.mapToDto(message);
+
+        assertThat(dto.getSubject()).isEqualTo("someSubject");
+        assertThat(dto.getSender()).satisfies(sender -> {
+            assertThat(sender.getMunicipalityId()).isEqualTo("someDefaultMunicipalityId");
+            assertThat(sender.getSupportInfo()).satisfies(supportInfo -> {
+                assertThat(supportInfo.getText()).isEqualTo("someDefaultSupportInfoText");
+                assertThat(supportInfo.getUrl()).isEqualTo("someDefaultSupportInfoUrl");
+                assertThat(supportInfo.getEmailAddress()).isEqualTo("someDefaultSupportInfoEmailAddress");
+                assertThat(supportInfo.getPhoneNumber()).isEqualTo("someDefaultSupportInfoPhoneNumber");
+            });
+        });
+        assertThat(dto.getPartyId()).isEqualTo(request.getParty().getPartyIds().get(0));
+        assertThat(dto.getContentType()).isEqualTo(ContentType.fromString(request.getContentType()));
+        assertThat(dto.getBody()).isEqualTo(request.getBody());
+        assertThat(dto.getAttachments()).hasSameSizeAs(request.getAttachments());
+
+    }
+
+    @Test
+    void test_mapToDto_whenSubjectIsMissing() {
+        when(mockDefaults.getDigitalMail()).thenReturn(mockDefaultsDigitalMailSettings);
+        when(mockDefaultsDigitalMailSettings.getSubject()).thenReturn("someDefaultSubject");
+
+        var request = createDigitalMailRequest(req -> req.setSubject(null));
+
+        var message = MessageEntity.builder()
+            .withMessageId(UUID.randomUUID().toString())
+            .withPartyId(request.getParty().getPartyIds().get(0))
+            .withType(MessageType.DIGITAL_MAIL)
+            .withStatus(MessageStatus.PENDING)
+            .withContent(GSON.toJson(request))
+            .build();
+        var dto = digitalMailProcessor.mapToDto(message);
+
+        assertThat(dto.getSubject()).isEqualTo("someDefaultSubject");
+        assertThat(dto.getPartyId()).isEqualTo(request.getParty().getPartyIds().get(0));
+        assertThat(dto.getContentType()).isEqualTo(ContentType.fromString(request.getContentType()));
+        assertThat(dto.getBody()).isEqualTo(request.getBody());
+        assertThat(dto.getAttachments()).hasSameSizeAs(request.getAttachments());
     }
 }

--- a/src/test/java/se/sundsvall/messaging/integration/digitalmailsender/DigitalMailSenderIntegrationMapperTests.java
+++ b/src/test/java/se/sundsvall/messaging/integration/digitalmailsender/DigitalMailSenderIntegrationMapperTests.java
@@ -1,35 +1,18 @@
 package se.sundsvall.messaging.integration.digitalmailsender;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import se.sundsvall.messaging.dto.DigitalMailDto;
 import se.sundsvall.messaging.model.ContentType;
+import se.sundsvall.messaging.model.Sender;
 
-@ExtendWith(MockitoExtension.class)
 class DigitalMailSenderIntegrationMapperTests {
 
-    @Mock
-    private DigitalMailSenderIntegrationProperties mockProperties;
-    @Mock
-    private DigitalMailSenderIntegrationProperties.Defaults mockDefaults;
-    @Mock
-    private DigitalMailSenderIntegrationProperties.Defaults.SupportInfo mockSupportInfo;
-
-    private DigitalMailSenderIntegrationMapper mapper;
-
-    @BeforeEach
-    void setUp() {
-        mapper = new DigitalMailSenderIntegrationMapper(mockProperties);
-    }
+    private final DigitalMailSenderIntegrationMapper mapper = new DigitalMailSenderIntegrationMapper();
 
     @Test
     void test_toDigitalMailRequest_whenDtoIsNull() {
@@ -38,16 +21,16 @@ class DigitalMailSenderIntegrationMapperTests {
 
     @Test
     void test_toDigitalMailRequest() {
-        when(mockProperties.getDefaults()).thenReturn(mockDefaults);
-        when(mockDefaults.getMunicipalityId()).thenReturn("someMunicipalityId");
-        when(mockDefaults.getSubject()).thenReturn("someDefaultSubject");
-        when(mockDefaults.getSupportInfo()).thenReturn(mockSupportInfo);
-        when(mockSupportInfo.getText()).thenReturn("someText");
-        when(mockSupportInfo.getEmailAddress()).thenReturn("someEmailAddress");
-        when(mockSupportInfo.getUrl()).thenReturn("someUrl");
-        when(mockSupportInfo.getPhoneNumber()).thenReturn("somePhoneNumber");
-
         var dto = DigitalMailDto.builder()
+            .withSender(Sender.DigitalMail.builder()
+                .withMunicipalityId("someMunicipalityId")
+                .withSupportInfo(Sender.DigitalMail.SupportInfo.builder()
+                    .withEmailAddress("someEmailAddress")
+                    .withPhoneNumber("somePhoneNumber")
+                    .withText("someText")
+                    .withUrl("someUrl")
+                    .build())
+                .build())
             .withPartyId("somePartyId")
             .withSubject("someSubject")
             .withContentType(ContentType.TEXT_PLAIN)
@@ -62,44 +45,6 @@ class DigitalMailSenderIntegrationMapperTests {
         var request = mapper.toDigitalMailRequest(dto);
 
         assertThat(request.getHeaderSubject()).isEqualTo("someSubject");
-        assertThat(request.getMunicipalityId()).isEqualTo("someMunicipalityId");
-        assertThat(request.getBodyInformation()).satisfies(bodyInformation -> {
-            assertThat(bodyInformation.getContentType()).isEqualTo(ContentType.TEXT_PLAIN.getValue());
-            assertThat(bodyInformation.getBody()).isEqualTo(dto.getBody());
-        });
-        assertThat(request.getAttachments()).hasSameSizeAs(dto.getAttachments());
-        assertThat(request.getAttachments().get(0)).satisfies(attachment -> {
-            assertThat(attachment.getFilename()).isEqualTo("someFilename");
-            assertThat(attachment.getContentType()).isEqualTo(ContentType.APPLICATION_PDF.getValue());
-            assertThat(attachment.getBody()).isEqualTo("someContent");
-        });
-    }
-
-    @Test
-    void test_toDigitalMailRequestWhenSubjectIsMissing() {
-        when(mockProperties.getDefaults()).thenReturn(mockDefaults);
-        when(mockDefaults.getMunicipalityId()).thenReturn("someMunicipalityId");
-        when(mockDefaults.getSubject()).thenReturn("someDefaultSubject");
-        when(mockDefaults.getSupportInfo()).thenReturn(mockSupportInfo);
-        when(mockSupportInfo.getText()).thenReturn("someText");
-        when(mockSupportInfo.getEmailAddress()).thenReturn("someEmailAddress");
-        when(mockSupportInfo.getUrl()).thenReturn("someUrl");
-        when(mockSupportInfo.getPhoneNumber()).thenReturn("somePhoneNumber");
-
-        var dto = DigitalMailDto.builder()
-            .withPartyId("somePartyId")
-            .withContentType(ContentType.TEXT_PLAIN)
-            .withBody("someBody")
-            .withAttachments(List.of(DigitalMailDto.AttachmentDto.builder()
-                .withFilename("someFilename")
-                .withContentType(ContentType.APPLICATION_PDF)
-                .withContent("someContent")
-                .build()))
-            .build();
-
-        var request = mapper.toDigitalMailRequest(dto);
-
-        assertThat(request.getHeaderSubject()).isEqualTo("someDefaultSubject");
         assertThat(request.getMunicipalityId()).isEqualTo("someMunicipalityId");
         assertThat(request.getBodyInformation()).satisfies(bodyInformation -> {
             assertThat(bodyInformation.getContentType()).isEqualTo(ContentType.TEXT_PLAIN.getValue());

--- a/src/test/java/se/sundsvall/messaging/integration/emailsender/EmailProcessorTests.java
+++ b/src/test/java/se/sundsvall/messaging/integration/emailsender/EmailProcessorTests.java
@@ -22,7 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
-import se.sundsvall.messaging.configuration.DefaultSettings;
+import se.sundsvall.messaging.configuration.Defaults;
 import se.sundsvall.messaging.configuration.RetryProperties;
 import se.sundsvall.messaging.dto.EmailDto;
 import se.sundsvall.messaging.integration.db.HistoryRepository;
@@ -47,7 +47,7 @@ class EmailProcessorTests {
     @Mock
     private EmailSenderIntegration mockEmailSenderIntegration;
     @Mock
-    private DefaultSettings mockDefaultSettings;
+    private Defaults mockDefaults;
 
     private EmailProcessor emailProcessor;
 
@@ -58,7 +58,7 @@ class EmailProcessorTests {
         when(mockRetryProperties.getMaxDelay()).thenReturn(Duration.ofMillis(100));
 
         emailProcessor = new EmailProcessor(mockRetryProperties, mockMessageRepository,
-            mockHistoryRepository, mockEmailSenderIntegration, mockDefaultSettings);
+            mockHistoryRepository, mockEmailSenderIntegration, mockDefaults);
     }
 
     @Test

--- a/src/test/java/se/sundsvall/messaging/integration/smssender/SmsProcessorTests.java
+++ b/src/test/java/se/sundsvall/messaging/integration/smssender/SmsProcessorTests.java
@@ -23,7 +23,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 
-import se.sundsvall.messaging.configuration.DefaultSettings;
+import se.sundsvall.messaging.configuration.Defaults;
 import se.sundsvall.messaging.configuration.RetryProperties;
 import se.sundsvall.messaging.dto.SmsDto;
 import se.sundsvall.messaging.integration.db.HistoryRepository;
@@ -50,7 +50,7 @@ class SmsProcessorTests {
     @Mock
     private SmsSenderIntegration mockSmsSenderIntegration;
     @Mock
-    private DefaultSettings mockDefaultSettings;
+    private Defaults mockDefaults;
 
     private SmsProcessor smsProcessor;
 
@@ -61,7 +61,7 @@ class SmsProcessorTests {
         when(mockRetryProperties.getMaxDelay()).thenReturn(Duration.ofMillis(100));
 
         smsProcessor = new SmsProcessor(mockRetryProperties, mockMessageRepository,
-            mockHistoryRepository, mockSmsSenderIntegration, mockDefaultSettings);
+            mockHistoryRepository, mockSmsSenderIntegration, mockDefaults);
     }
 
     @Test

--- a/src/test/java/se/sundsvall/messaging/processor/MessageProcessorTests.java
+++ b/src/test/java/se/sundsvall/messaging/processor/MessageProcessorTests.java
@@ -20,7 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 
 import se.sundsvall.messaging.api.model.EmailRequest;
-import se.sundsvall.messaging.configuration.DefaultSettings;
+import se.sundsvall.messaging.configuration.Defaults;
 import se.sundsvall.messaging.integration.db.HistoryRepository;
 import se.sundsvall.messaging.integration.db.MessageRepository;
 import se.sundsvall.messaging.integration.db.entity.HistoryEntity;
@@ -45,7 +45,7 @@ class MessageProcessorTests {
     @Mock
     private HistoryRepository mockHistoryRepository;
     @Mock
-    private DefaultSettings mockDefaultSettings;
+    private Defaults mockDefaults;
     @Mock
     private FeedbackSettingsIntegration mockFeedbackSettingsIntegration;
 
@@ -57,7 +57,7 @@ class MessageProcessorTests {
     @BeforeEach
     void setUp() {
         messageProcessor = new MessageProcessor(mockEventPublisher, mockMessageRepository,
-            mockHistoryRepository, mockDefaultSettings, mockFeedbackSettingsIntegration);
+            mockHistoryRepository, mockDefaults, mockFeedbackSettingsIntegration);
     }
 
     @Test

--- a/src/test/resources/application-junit.properties
+++ b/src/test/resources/application-junit.properties
@@ -6,10 +6,16 @@ spring.flyway.enabled=false
 
 spring.jpa.hibernate.ddl-auto=update
 
-# Sender defaults
-messaging.default-sender.sms-name=Sender
-messaging.default-sender.email-name=Longer Sender
-messaging.default-sender.email-address=longer.sender@somehost.com
+# Defaults
+messaging.defaults.sms.name=Sender
+messaging.defaults.email.name=Longer Sender
+messaging.defaults.email.address=longer.sender@somehost.com
+messaging.defaults.digital-mail.municipality-id=someMunicipalityId
+messaging.defaults.digital-mail.subject=someSubject
+messaging.defaults.digital-mail.support-info.text=someInfoText
+messaging.defaults.digital-mail.support-info.email-address=someEmailAddress
+messaging.defaults.digital-mail.support-info.phone-number=somePhoneNumber
+messaging.defaults.digital-mail.support-info.url=someUrl
 
 # SmsSender integration
 integration.sms-sender.base-url=http://sms-sender/api
@@ -42,14 +48,6 @@ integration.digital-mail-sender.client-id=someClientId
 integration.digital-mail-sender.client-secret=someClientSecret
 integration.digital-mail-sender.poll-delay=2s
 integration.digital-mail-message-sender.max-retries=3
-
-# DigitalMailSender integration defaults
-integration.digital-mail-sender.defaults.municipality-id=someMunicipalityId
-integration.digital-mail-sender.defaults.subject=someSubject
-integration.digital-mail-sender.defaults.support-info.text=someInfoText
-integration.digital-mail-sender.defaults.support-info.email-address=someEmailAddress
-integration.digital-mail-sender.defaults.support-info.phone-number=somePhoneNumber
-integration.digital-mail-sender.defaults.support-info.url=someUrl
 
 # SnailmailSender integration
 integration.snailmail-sender.base-url=http://snailmail-sender/api


### PR DESCRIPTION
Enables the ability to override default values for digital-mail subject and support info on a per-request-basis.

Also, includes a refactoring/unification of the digital-mail defaults to align with the e-mail and sms defaults handling.