### PR TITLE
UF-XYZ - ALL delivery mode for /letter

### DIFF
--- a/src/integration-test/java/apptest/LetterIT.java
+++ b/src/integration-test/java/apptest/LetterIT.java
@@ -20,9 +20,7 @@ import se.sundsvall.messaging.integration.db.MessageRepository;
 import se.sundsvall.messaging.model.MessageStatus;
 import se.sundsvall.messaging.model.MessageType;
 
-@WireMockAppTestSuite(
-        files = "classpath:/LetterIT/",
-        classes = Application.class)
+@WireMockAppTestSuite(files = "classpath:/LetterIT/", classes = Application.class)
 @Transactional
 public class LetterIT extends AbstractMessagingAppTest {
 
@@ -42,12 +40,12 @@ public class LetterIT extends AbstractMessagingAppTest {
     @Test
     void test1_successfulRequestByDigital() throws Exception {
         var response = setupCall()
-                .withServicePath(SERVICE_PATH)
-                .withRequest("request.json")
-                .withHttpMethod(HttpMethod.POST)
-                .withExpectedResponseStatus(HttpStatus.OK)
-                .sendRequestAndVerifyResponse()
-                .andReturnBody(MessagesResponse.class);
+            .withServicePath(SERVICE_PATH)
+            .withRequest("request.json")
+            .withHttpMethod(HttpMethod.POST)
+            .withExpectedResponseStatus(HttpStatus.OK)
+            .sendRequestAndVerifyResponse()
+            .andReturnBody(MessagesResponse.class);
 
         assertThat(response.getMessageIds()).hasSize(1);
 
@@ -61,23 +59,23 @@ public class LetterIT extends AbstractMessagingAppTest {
         assertThat(messageRepository.existsByMessageId(messageId)).isFalse();
         // Make sure that there exists a history entry with the correct id and status
         assertThat(historyRepository.findByMessageId(messageId))
-                .isNotNull()
-                .allSatisfy(historyEntry -> {
-                    assertThat(historyEntry.getMessageId()).isEqualTo(messageId);
-                    assertThat(historyEntry.getStatus()).isEqualTo(MessageStatus.SENT);
-                    assertThat(historyEntry.getMessageType()).isEqualTo(MessageType.LETTER);
-                });
+            .isNotNull()
+            .allSatisfy(historyEntry -> {
+                assertThat(historyEntry.getMessageId()).isEqualTo(messageId);
+                assertThat(historyEntry.getStatus()).isEqualTo(MessageStatus.SENT);
+                assertThat(historyEntry.getMessageType()).isEqualTo(MessageType.LETTER);
+            });
     }
 
     @Test
     void test2_ErrorFromDigital_SuccessfulSnailmail() throws Exception {
         var response = setupCall()
-                .withServicePath(SERVICE_PATH)
-                .withRequest("request.json")
-                .withHttpMethod(HttpMethod.POST)
-                .withExpectedResponseStatus(HttpStatus.OK)
-                .sendRequestAndVerifyResponse()
-                .andReturnBody(MessagesResponse.class);
+            .withServicePath(SERVICE_PATH)
+            .withRequest("request.json")
+            .withHttpMethod(HttpMethod.POST)
+            .withExpectedResponseStatus(HttpStatus.OK)
+            .sendRequestAndVerifyResponse()
+            .andReturnBody(MessagesResponse.class);
 
         assertThat(response.getMessageIds()).hasSize(1);
 
@@ -91,23 +89,23 @@ public class LetterIT extends AbstractMessagingAppTest {
         assertThat(messageRepository.existsByMessageId(messageId)).isFalse();
         // Make sure that there exists a history entry with the correct id and status
         assertThat(historyRepository.findByMessageId(messageId))
-                .isNotNull()
-                .allSatisfy(historyEntry -> {
-                    assertThat(historyEntry.getMessageId()).isEqualTo(messageId);
-                    assertThat(historyEntry.getStatus()).isEqualTo(MessageStatus.SENT);
-                    assertThat(historyEntry.getMessageType()).isEqualTo(MessageType.LETTER);
-                });
+            .isNotNull()
+            .allSatisfy(historyEntry -> {
+                assertThat(historyEntry.getMessageId()).isEqualTo(messageId);
+                assertThat(historyEntry.getStatus()).isEqualTo(MessageStatus.SENT);
+                assertThat(historyEntry.getMessageType()).isEqualTo(MessageType.LETTER);
+            });
     }
 
     @Test
     void test3_ErrorFromDigital_ErrorFromSnailmail() throws Exception {
         var response = setupCall()
-                .withServicePath(SERVICE_PATH)
-                .withRequest("request.json")
-                .withHttpMethod(HttpMethod.POST)
-                .withExpectedResponseStatus(HttpStatus.OK)
-                .sendRequestAndVerifyResponse()
-                .andReturnBody(MessagesResponse.class);
+            .withServicePath(SERVICE_PATH)
+            .withRequest("request.json")
+            .withHttpMethod(HttpMethod.POST)
+            .withExpectedResponseStatus(HttpStatus.OK)
+            .sendRequestAndVerifyResponse()
+            .andReturnBody(MessagesResponse.class);
 
         assertThat(response.getMessageIds()).hasSize(1);
 
@@ -121,13 +119,13 @@ public class LetterIT extends AbstractMessagingAppTest {
         assertThat(messageRepository.existsByMessageId(messageId)).isFalse();
         // Make sure that there exists a history entry with the correct id and status
         assertThat(historyRepository.findByMessageId(messageId))
-                .isNotNull()
-                .allSatisfy(historyEntry -> {
-                    assertThat(historyEntry.getMessageId()).isEqualTo(messageId);
-                    assertThat(historyEntry.getStatus()).isEqualTo(MessageStatus.FAILED);
-                    assertThat(historyEntry.getMessageType()).isEqualTo(MessageType.LETTER);
-                });
+            .isNotNull()
+            .allSatisfy(historyEntry -> {
+                assertThat(historyEntry.getMessageId()).isEqualTo(messageId);
+                assertThat(historyEntry.getStatus()).isEqualTo(MessageStatus.FAILED);
+                assertThat(historyEntry.getMessageType()).isEqualTo(MessageType.LETTER);
+            });
     }
 
-
+    // TODO: create an additional app-test that tests the "ALL" delivery mode stuff...
 }

--- a/src/integration-test/resources/LetterIT/__files/test1_successfulRequestByDigital/request.json
+++ b/src/integration-test/resources/LetterIT/__files/test1_successfulRequestByDigital/request.json
@@ -10,7 +10,7 @@
   "department": "Some department",
   "attachments": [
     {
-      "deliveryMode": "DIGITAL",
+      "deliveryMode": "DIGITAL_MAIL",
       "filename": "someFile.txt",
       "contentType": "application/pdf",
       "content": "bG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQK"

--- a/src/integration-test/resources/LetterIT/__files/test2_ErrorFromDigital_SuccessfulSnailmail/request.json
+++ b/src/integration-test/resources/LetterIT/__files/test2_ErrorFromDigital_SuccessfulSnailmail/request.json
@@ -10,13 +10,13 @@
   "department": "Some department",
   "attachments": [
     {
-      "deliveryMode": "DIGITAL",
+      "deliveryMode": "DIGITAL_MAIL",
       "filename": "someFile.txt",
       "contentType": "application/pdf",
       "content": "bG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQK"
     },
     {
-      "deliveryMode": "SNAIL",
+      "deliveryMode": "SNAIL_MAIL",
       "filename": "someFile.txt",
       "contentType": "application/pdf",
       "content": "bG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQK"

--- a/src/integration-test/resources/LetterIT/__files/test3_ErrorFromDigital_ErrorFromSnailmail/request.json
+++ b/src/integration-test/resources/LetterIT/__files/test3_ErrorFromDigital_ErrorFromSnailmail/request.json
@@ -10,13 +10,13 @@
   "department": "Some department",
   "attachments": [
     {
-      "deliveryMode": "DIGITAL",
+      "deliveryMode": "DIGITAL_MAIL",
       "filename": "someFile.txt",
       "contentType": "application/pdf",
       "content": "bG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQK"
     },
     {
-      "deliveryMode": "SNAIL",
+      "deliveryMode": "SNAIL_MAIL",
       "filename": "someFile.txt",
       "contentType": "application/pdf",
       "content": "bG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQK"

--- a/src/integration-test/resources/openapi.yml
+++ b/src/integration-test/resources/openapi.yml
@@ -7,13 +7,13 @@ info:
     url: https://opensource.org/licenses/MIT
   version: "2.5"
 servers:
-  - url: http://localhost:8080
-    description: Generated server url
+- url: http://localhost:8080
+  description: Generated server url
 paths:
   /webmessage:
     post:
       tags:
-        - Sending Resources
+      - Sending Resources
       summary: Send a single web message
       operationId: sendWebMessage
       requestBody:
@@ -23,15 +23,6 @@ paths:
               $ref: '#/components/schemas/WebMessageRequest'
         required: true
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
         "200":
           description: Successful Operation
           content:
@@ -41,6 +32,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         "500":
           description: Internal Server Error
           content:
@@ -53,7 +53,7 @@ paths:
   /snailmail:
     post:
       tags:
-        - Sending Resources
+      - Sending Resources
       summary: Send a single snailmail
       operationId: sendSnailmail
       requestBody:
@@ -63,15 +63,6 @@ paths:
               $ref: '#/components/schemas/SnailmailRequest'
         required: true
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
         "200":
           description: Successful Operation
           content:
@@ -81,6 +72,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         "500":
           description: Internal Server Error
           content:
@@ -93,7 +93,7 @@ paths:
   /sms:
     post:
       tags:
-        - Sending Resources
+      - Sending Resources
       summary: Send a single SMS
       operationId: sendSms
       requestBody:
@@ -103,15 +103,6 @@ paths:
               $ref: '#/components/schemas/SmsRequest'
         required: true
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
         "200":
           description: Successful Operation
           content:
@@ -121,6 +112,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         "500":
           description: Internal Server Error
           content:
@@ -133,7 +133,7 @@ paths:
   /messages:
     post:
       tags:
-        - Sending Resources
+      - Sending Resources
       summary: Send a batch of messages as e-mail or SMS to a list of parties
       operationId: sendMessages
       requestBody:
@@ -143,15 +143,6 @@ paths:
               $ref: '#/components/schemas/MessageRequest'
         required: true
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
         "200":
           description: Successful Operation
           content:
@@ -161,6 +152,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessagesResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         "500":
           description: Internal Server Error
           content:
@@ -173,7 +173,7 @@ paths:
   /letter:
     post:
       tags:
-        - Sending Resources
+      - Sending Resources
       summary: Send a single letter as digital mail or snail mail
       operationId: sendLetter
       requestBody:
@@ -183,15 +183,6 @@ paths:
               $ref: '#/components/schemas/LetterRequest'
         required: true
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
         "200":
           description: Successful Operation
           content:
@@ -201,6 +192,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         "500":
           description: Internal Server Error
           content:
@@ -213,7 +213,7 @@ paths:
   /email:
     post:
       tags:
-        - Sending Resources
+      - Sending Resources
       summary: Send a single e-mail
       operationId: sendEmail
       requestBody:
@@ -223,15 +223,6 @@ paths:
               $ref: '#/components/schemas/EmailRequest'
         required: true
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
         "200":
           description: Successful Operation
           content:
@@ -241,6 +232,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         "500":
           description: Internal Server Error
           content:
@@ -253,7 +253,7 @@ paths:
   /digitalmail:
     post:
       tags:
-        - Sending Resources
+      - Sending Resources
       summary: Send a single digital mail to one or more parties
       operationId: sendDigitalMail
       requestBody:
@@ -263,15 +263,6 @@ paths:
               $ref: '#/components/schemas/DigitalMailRequest'
         required: true
       responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
         "200":
           description: Successful Operation
           content:
@@ -281,6 +272,15 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessagesResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
         "500":
           description: Internal Server Error
           content:
@@ -293,16 +293,25 @@ paths:
   /status/{messageId}:
     get:
       tags:
-        - Status and History Resources
+      - Status and History Resources
       summary: Get the status for a single message and its deliveries
       operationId: getMessageStatus
       parameters:
-        - name: messageId
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: messageId
+        in: path
+        required: true
+        schema:
+          type: string
       responses:
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessageStatusResponse'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/MessageStatusResponse'
         "404":
           description: Not Found
           content:
@@ -321,30 +330,30 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "200":
-          description: Successful Operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MessageStatusResponse'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/MessageStatusResponse'
   /message/{messageId}:
     get:
       tags:
-        - Status and History Resources
+      - Status and History Resources
       summary: Get a message and all its deliveries
       operationId: getMessage
       parameters:
-        - name: messageId
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: messageId
+        in: path
+        required: true
+        schema:
+          type: string
       responses:
         "404":
           description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -361,51 +370,33 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/HistoryResponse'
-        "500":
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Problem'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Problem'
   /conversation-history/{partyId}:
     get:
       tags:
-        - Status and History Resources
+      - Status and History Resources
       summary: Get the entire conversation history for a given party
       operationId: getConversationHistory
       parameters:
-        - name: partyId
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: from
-          in: query
-          description: "From-date (inclusive). Format: yyyy-MM-dd (ISO8601)"
-          required: false
-          schema:
-            type: string
-            format: date
-        - name: to
-          in: query
-          description: "To-date (inclusive). Format: yyyy-MM-dd (ISO8601)"
-          required: false
-          schema:
-            type: string
-            format: date
+      - name: partyId
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: from
+        in: query
+        description: "From-date (inclusive). Format: yyyy-MM-dd (ISO8601)"
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: to
+        in: query
+        description: "To-date (inclusive). Format: yyyy-MM-dd (ISO8601)"
+        required: false
+        schema:
+          type: string
+          format: date
       responses:
-        "200":
-          description: Successful Operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HistoryResponse'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/HistoryResponse'
         "500":
           description: Internal Server Error
           content:
@@ -415,19 +406,37 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HistoryResponse'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/HistoryResponse'
   /batch-status/{batchId}:
     get:
       tags:
-        - Status and History Resources
+      - Status and History Resources
       summary: "Get the status for a message batch, its messages and their deliveries"
       operationId: getBatchStatus
       parameters:
-        - name: batchId
-          in: path
-          required: true
-          schema:
-            type: string
+      - name: batchId
+        in: path
+        required: true
+        schema:
+          type: string
       responses:
+        "200":
+          description: Successful Operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchStatusResponse'
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BatchStatusResponse'
         "404":
           description: Not Found
           content:
@@ -446,19 +455,10 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "200":
-          description: Successful Operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BatchStatusResponse'
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/BatchStatusResponse'
   /api-docs:
     get:
       tags:
-        - API
+      - API
       summary: OpenAPI
       operationId: getApiDocs
       responses:
@@ -475,8 +475,8 @@ components:
   schemas:
     ExternalReference:
       required:
-        - key
-        - value
+      - key
+      - value
       type: object
       properties:
         key:
@@ -490,17 +490,17 @@ components:
       description: External references
     Header:
       required:
-        - values
+      - values
       type: object
       properties:
         name:
           type: string
           description: The header name
           enum:
-            - DISTRIBUTION_RULE
-            - CATEGORY
-            - FACILITY_ID
-            - TYPE
+          - DISTRIBUTION_RULE
+          - CATEGORY
+          - FACILITY_ID
+          - TYPE
         values:
           type: array
           description: The header values
@@ -536,7 +536,7 @@ components:
       description: Attachment
     WebMessageRequest:
       required:
-        - message
+      - message
       type: object
       properties:
         party:
@@ -554,6 +554,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/WebMessageAttachment'
+    MessageResponse:
+      type: object
+      properties:
+        messageId:
+          type: string
     Problem:
       type: object
       properties:
@@ -581,15 +586,10 @@ components:
           format: int32
         reasonPhrase:
           type: string
-    MessageResponse:
-      type: object
-      properties:
-        messageId:
-          type: string
     SnailmailAttachment:
       required:
-        - content
-        - name
+      - content
+      - name
       type: object
       properties:
         content:
@@ -607,8 +607,8 @@ components:
       description: Attachment
     SnailmailRequest:
       required:
-        - department
-        - personId
+      - department
+      - personId
       type: object
       properties:
         party:
@@ -635,7 +635,7 @@ components:
             $ref: '#/components/schemas/SnailmailAttachment'
     Sms:
       required:
-        - name
+      - name
       type: object
       properties:
         name:
@@ -647,8 +647,8 @@ components:
       description: Sender
     SmsRequest:
       required:
-        - message
-        - mobileNumber
+      - message
+      - mobileNumber
       type: object
       properties:
         party:
@@ -668,15 +668,15 @@ components:
           description: Message
     DigitalMail:
       required:
-        - supportInfo
+      - supportInfo
       type: object
       properties:
         supportInfo:
           $ref: '#/components/schemas/SupportInfo'
     Email:
       required:
-        - address
-        - name
+      - address
+      - name
       type: object
       properties:
         name:
@@ -692,7 +692,7 @@ components:
           example: sender@sender.se
     Message:
       required:
-        - message
+      - message
       type: object
       properties:
         party:
@@ -735,10 +735,10 @@ components:
       description: Sender
     SupportInfo:
       required:
-        - emailAddress
-        - phoneNumber
-        - text
-        - url
+      - emailAddress
+      - phoneNumber
+      - text
+      - url
       type: object
       properties:
         text:
@@ -760,22 +760,25 @@ components:
             type: string
     DigitalMailAttachment:
       required:
-        - content
-        - delivery mode
-        - filename
+      - content
+      - deliveryMode
+      - filename
       type: object
       properties:
-        delivery mode:
+        deliveryMode:
           type: string
-          description: Is attachment for Digital or Snail mail?
+          description: |
+            Delivery mode, to indicate whether an attachment is intended/allowed to be used for
+            digital mail, snail-mail or both
           enum:
-            - DIGITAL
-            - SNAIL
+          - ALL
+          - DIGITAL_MAIL
+          - SNAIL_MAIL
         contentType:
           type: string
           description: Content type
           enum:
-            - application/pdf
+          - application/pdf
         content:
           type: string
           description: Content (BASE64-encoded)
@@ -785,9 +788,9 @@ components:
       description: Attachments
     LetterRequest:
       required:
-        - body
-        - contentType
-        - department
+      - body
+      - contentType
+      - department
       type: object
       properties:
         party:
@@ -805,8 +808,8 @@ components:
           type: string
           description: Content type
           enum:
-            - text/plain
-            - text/html
+          - text/plain
+          - text/html
         body:
           type: string
           description: Body (BASE64-encoded)
@@ -821,7 +824,7 @@ components:
             $ref: '#/components/schemas/DigitalMailAttachment'
     Parties:
       required:
-        - partyIds
+      - partyIds
       type: object
       properties:
         partyIds:
@@ -838,8 +841,8 @@ components:
       description: Parties
     EmailAttachment:
       required:
-        - content
-        - name
+      - content
+      - name
       type: object
       properties:
         content:
@@ -857,8 +860,8 @@ components:
       description: Attachment
     EmailRequest:
       required:
-        - emailAddress
-        - subject
+      - emailAddress
+      - subject
       type: object
       properties:
         party:
@@ -888,8 +891,8 @@ components:
             $ref: '#/components/schemas/EmailAttachment'
     DigitalMailRequest:
       required:
-        - body
-        - contentType
+      - body
+      - contentType
       type: object
       properties:
         party:
@@ -909,8 +912,8 @@ components:
           type: string
           description: Content type
           enum:
-            - text/plain
-            - text/html
+          - text/plain
+          - text/html
         body:
           type: string
           description: Body (BASE64-encoded)
@@ -929,12 +932,12 @@ components:
         status:
           type: string
           enum:
-            - AWAITING_FEEDBACK
-            - PENDING
-            - SENT
-            - FAILED
-            - NO_FEEDBACK_SETTINGS_FOUND
-            - NO_FEEDBACK_WANTED
+          - AWAITING_FEEDBACK
+          - PENDING
+          - SENT
+          - FAILED
+          - NO_FEEDBACK_SETTINGS_FOUND
+          - NO_FEEDBACK_WANTED
     HistoryResponse:
       type: object
       properties:
@@ -943,22 +946,22 @@ components:
         messageType:
           type: string
           enum:
-            - MESSAGE
-            - EMAIL
-            - SMS
-            - WEB_MESSAGE
-            - DIGITAL_MAIL
-            - SNAIL_MAIL
-            - LETTER
+          - MESSAGE
+          - EMAIL
+          - SMS
+          - WEB_MESSAGE
+          - DIGITAL_MAIL
+          - SNAIL_MAIL
+          - LETTER
         status:
           type: string
           enum:
-            - AWAITING_FEEDBACK
-            - PENDING
-            - SENT
-            - FAILED
-            - NO_FEEDBACK_SETTINGS_FOUND
-            - NO_FEEDBACK_WANTED
+          - AWAITING_FEEDBACK
+          - PENDING
+          - SENT
+          - FAILED
+          - NO_FEEDBACK_SETTINGS_FOUND
+          - NO_FEEDBACK_WANTED
         timestamp:
           type: string
           format: date-time

--- a/src/integration-test/resources/openapi.yml
+++ b/src/integration-test/resources/openapi.yml
@@ -771,7 +771,7 @@ components:
             Delivery mode, to indicate whether an attachment is intended/allowed to be used for
             digital mail, snail-mail or both
           enum:
-          - ALL
+          - BOTH
           - DIGITAL_MAIL
           - SNAIL_MAIL
         contentType:

--- a/src/main/java/se/sundsvall/messaging/api/model/DigitalMailRequest.java
+++ b/src/main/java/se/sundsvall/messaging/api/model/DigitalMailRequest.java
@@ -61,7 +61,7 @@ public class DigitalMailRequest extends BatchRequest {
         private String content;
 
         @NotBlank
-        @Schema(name = "filename", description = "Filename")
+        @Schema(description = "Filename")
         private String filename;
     }
 }

--- a/src/main/java/se/sundsvall/messaging/api/model/LetterRequest.java
+++ b/src/main/java/se/sundsvall/messaging/api/model/LetterRequest.java
@@ -76,7 +76,7 @@ public class LetterRequest extends BatchRequest {
         """
     )
     public enum DeliveryMode {
-        ALL,
+        BOTH,
         DIGITAL_MAIL,
         SNAIL_MAIL
     }

--- a/src/main/java/se/sundsvall/messaging/api/model/LetterRequest.java
+++ b/src/main/java/se/sundsvall/messaging/api/model/LetterRequest.java
@@ -38,7 +38,7 @@ public class LetterRequest extends BatchRequest {
 
     @NotBlank
     @Schema(description = "Department and unit that should be billed in case of snailmail",
-            example = "SBK" + "(Gatuavdelningen, Trafiksektionen)")
+        example = "SBK" + "(Gatuavdelningen, Trafiksektionen)")
     private String department;
 
     @Valid
@@ -54,7 +54,7 @@ public class LetterRequest extends BatchRequest {
     public static class Attachment {
 
         @NotNull
-        @Schema(name = "delivery mode", description = "Is attachment for Digital or Snail mail?")
+        @Schema(description = "Delivery mode")
         private DeliveryMode deliveryMode;
 
         @OneOf("application/pdf")
@@ -66,13 +66,18 @@ public class LetterRequest extends BatchRequest {
         private String content;
 
         @NotBlank
-        @Schema(name = "filename", description = "Filename")
+        @Schema(description = "Filename")
         private String filename;
     }
 
+    @Schema(description = """
+        Delivery mode, to indicate whether an attachment is intended/allowed to be used for 
+        digital mail, snail-mail or both
+        """
+    )
     public enum DeliveryMode {
-        DIGITAL, SNAIL
+        ALL,
+        DIGITAL_MAIL,
+        SNAIL_MAIL
     }
-
-
 }

--- a/src/main/java/se/sundsvall/messaging/processor/LetterProcessor.java
+++ b/src/main/java/se/sundsvall/messaging/processor/LetterProcessor.java
@@ -1,7 +1,7 @@
 package se.sundsvall.messaging.processor;
 
 
-import static se.sundsvall.messaging.api.model.LetterRequest.DeliveryMode.ALL;
+import static se.sundsvall.messaging.api.model.LetterRequest.DeliveryMode.BOTH;
 import static se.sundsvall.messaging.api.model.LetterRequest.DeliveryMode.DIGITAL_MAIL;
 import static se.sundsvall.messaging.api.model.LetterRequest.DeliveryMode.SNAIL_MAIL;
 
@@ -222,10 +222,10 @@ public class LetterProcessor extends Processor {
     }
 
     private boolean isAttachmentIntendedForDigitalMail(final LetterRequest.Attachment attachment) {
-        return attachment.getDeliveryMode().equals(ALL) || attachment.getDeliveryMode().equals(DIGITAL_MAIL);
+        return attachment.getDeliveryMode().equals(BOTH) || attachment.getDeliveryMode().equals(DIGITAL_MAIL);
     }
 
     private boolean isAttachmentIntendedForSnailMail(final LetterRequest.Attachment attachment) {
-        return attachment.getDeliveryMode().equals(ALL) || attachment.getDeliveryMode().equals(SNAIL_MAIL);
+        return attachment.getDeliveryMode().equals(BOTH) || attachment.getDeliveryMode().equals(SNAIL_MAIL);
     }
 }

--- a/src/main/java/se/sundsvall/messaging/processor/LetterProcessor.java
+++ b/src/main/java/se/sundsvall/messaging/processor/LetterProcessor.java
@@ -1,8 +1,9 @@
 package se.sundsvall.messaging.processor;
 
 
-import static se.sundsvall.messaging.api.model.LetterRequest.DeliveryMode.DIGITAL;
-import static se.sundsvall.messaging.api.model.LetterRequest.DeliveryMode.SNAIL;
+import static se.sundsvall.messaging.api.model.LetterRequest.DeliveryMode.ALL;
+import static se.sundsvall.messaging.api.model.LetterRequest.DeliveryMode.DIGITAL_MAIL;
+import static se.sundsvall.messaging.api.model.LetterRequest.DeliveryMode.SNAIL_MAIL;
 
 import java.util.List;
 import java.util.Optional;
@@ -76,7 +77,7 @@ public class LetterProcessor extends Processor {
 
         var digitalAttachments = GSON.fromJson(message.getContent(), LetterRequest.class)
             .getAttachments().stream()
-            .filter(attachment -> attachment.getDeliveryMode().equals(DIGITAL))
+            .filter(this::isAttachmentIntendedForDigitalMail)
             .toList();
 
         sendDigitalMail(message, event, digitalAttachments);
@@ -116,7 +117,7 @@ public class LetterProcessor extends Processor {
     private void sendSnailMail(final MessageEntity message, final IncomingLetterEvent event) {
         var snailAndFailedAttachments = GSON.fromJson(message.getContent(), LetterRequest.class)
             .getAttachments().stream()
-            .filter(attachment -> attachment.getDeliveryMode().equals(SNAIL))
+            .filter(this::isAttachmentIntendedForSnailMail)
             .toList();
 
         if (snailAndFailedAttachments.isEmpty()) {
@@ -218,5 +219,13 @@ public class LetterProcessor extends Processor {
         } else {
             return request.handleResultIf(response -> response.getStatusCode() != HttpStatus.OK).build();
         }
+    }
+
+    private boolean isAttachmentIntendedForDigitalMail(final LetterRequest.Attachment attachment) {
+        return attachment.getDeliveryMode().equals(ALL) || attachment.getDeliveryMode().equals(DIGITAL_MAIL);
+    }
+
+    private boolean isAttachmentIntendedForSnailMail(final LetterRequest.Attachment attachment) {
+        return attachment.getDeliveryMode().equals(ALL) || attachment.getDeliveryMode().equals(SNAIL_MAIL);
     }
 }

--- a/src/test/java/se/sundsvall/messaging/TestDataFactory.java
+++ b/src/test/java/se/sundsvall/messaging/TestDataFactory.java
@@ -1,7 +1,7 @@
 package se.sundsvall.messaging;
 
-import static se.sundsvall.messaging.api.model.LetterRequest.DeliveryMode.DIGITAL;
-import static se.sundsvall.messaging.api.model.LetterRequest.DeliveryMode.SNAIL;
+import static se.sundsvall.messaging.api.model.LetterRequest.DeliveryMode.DIGITAL_MAIL;
+import static se.sundsvall.messaging.api.model.LetterRequest.DeliveryMode.SNAIL_MAIL;
 
 import java.util.List;
 import java.util.UUID;
@@ -230,13 +230,13 @@ public final class TestDataFactory {
                 .withDepartment("someDepartment")
                 .withAttachments(List.of(
                         LetterRequest.Attachment.builder()
-                                .withDeliveryMode(DIGITAL)
+                                .withDeliveryMode(DIGITAL_MAIL)
                                 .withContentType(ContentType.APPLICATION_PDF.getValue())
                                 .withContent("someContent")
                                 .withFilename("someFilename")
                                 .build(),
                         LetterRequest.Attachment.builder()
-                                .withDeliveryMode(SNAIL)
+                                .withDeliveryMode(SNAIL_MAIL)
                                 .withContentType(ContentType.APPLICATION_PDF.getValue())
                                 .withContent("someContent")
                                 .withFilename("someFilename")

--- a/src/test/java/se/sundsvall/messaging/processor/LetterProcessorTests.java
+++ b/src/test/java/se/sundsvall/messaging/processor/LetterProcessorTests.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static se.sundsvall.messaging.TestDataFactory.createLetterRequest;
-import static se.sundsvall.messaging.api.model.LetterRequest.DeliveryMode.DIGITAL;
+import static se.sundsvall.messaging.api.model.LetterRequest.DeliveryMode.DIGITAL_MAIL;
 import static se.sundsvall.messaging.processor.Processor.GSON;
 
 import java.time.Duration;
@@ -177,7 +177,7 @@ public class LetterProcessorTests {
         when(mockDefaults.getDigitalMail()).thenReturn(mockDefaultsDigitalMailSettings);
         when(mockDefaultsDigitalMailSettings.getMunicipalityId()).thenReturn("someMunicipalityId");
         var letterRequest = createLetterRequest(req -> req.setAttachments(List.of(LetterRequest.Attachment.builder()
-                .withDeliveryMode(DIGITAL)
+                .withDeliveryMode(DIGITAL_MAIL)
                 .withContentType(ContentType.APPLICATION_PDF.getValue())
                 .withContent("someContent")
                 .withFilename("someFilename")


### PR DESCRIPTION
Adds an additional `ALL` attachment delivery mode, for attachments allowed/intended for both `DIGITAL_MAIL` and `SNAIL_MAIL`.

Also renames the old delivery mode enum constants to be über-explicit...