### PR TITLE
UF-XYZ - Letter constraints

### DIFF
--- a/src/integration-test/resources/openapi.yml
+++ b/src/integration-test/resources/openapi.yml
@@ -1137,8 +1137,6 @@ components:
     LetterRequest:
       required:
       - attachments
-      - body
-      - contentType
       - department
       - party
       - subject

--- a/src/main/java/se/sundsvall/messaging/api/model/request/LetterRequest.java
+++ b/src/main/java/se/sundsvall/messaging/api/model/request/LetterRequest.java
@@ -40,12 +40,10 @@ public record LetterRequest(
         @Schema(description = "Sender")
         Sender sender,
 
-        @NotBlank
         @OneOf({"text/plain", "text/html"})
         @Schema(description = "Content type", allowableValues = {"text/plain", "text/html"})
         String contentType,
 
-        @NotBlank
         @Schema(description = "Body (plain text if contentType is set to 'text/plain', BASE64-encoded if contentType is set to 'text/html')")
         String body,
 

--- a/src/test/java/se/sundsvall/messaging/api/model/request/LetterRequestConstraintValidationTests.java
+++ b/src/test/java/se/sundsvall/messaging/api/model/request/LetterRequestConstraintValidationTests.java
@@ -164,32 +164,8 @@ class LetterRequestConstraintValidationTests {
     }
 
     @Test
-    void shouldFailWithNullContentType() {
-        assertThat(validRequest.withContentType(null))
-            .hasConstraintViolation("contentType", "must not be blank")
-            .hasConstraintViolation("contentType", "must be one of: [text/plain, text/html]");
-    }
-
-    @Test
-    void shouldFailWithBlankContentType() {
-        assertThat(validRequest.withContentType(null))
-            .hasConstraintViolation("contentType", "must not be blank")
-            .hasConstraintViolation("contentType", "must be one of: [text/plain, text/html]");
-    }
-
-    @Test
     void shouldFailWithInvalidContentType() {
         assertThat(validRequest.withContentType("invalid-content-type"))
             .hasSingleConstraintViolation("contentType", "must be one of: [text/plain, text/html]");
-    }
-
-    @Test
-    void shouldFailWithNullBody() {
-        assertThat(validRequest.withBody(null)).hasSingleConstraintViolation("body", "must not be blank");
-    }
-
-    @Test
-    void shouldFailWithBlankBody() {
-        assertThat(validRequest.withBody(" ")).hasSingleConstraintViolation("body", "must not be blank");
     }
 }


### PR DESCRIPTION
Eases up on some letter constraints, no longer requiring body and contentType to be set