### PR TITLE
UF-5221 - Async delivery bug

### DIFF
--- a/src/main/java/se/sundsvall/messaging/service/MessageEventHandler.java
+++ b/src/main/java/se/sundsvall/messaging/service/MessageEventHandler.java
@@ -26,6 +26,6 @@ class MessageEventHandler {
             .orElseThrow(() -> Problem.valueOf(Status.INTERNAL_SERVER_ERROR,
                 "Unable to send " + event.getMessageType() + " with id " + event.getDeliveryId()));
         // Deliver it
-        messageService.deliver(message);
+        messageService.sendMessage(message);
     }
 }

--- a/src/test/java/se/sundsvall/messaging/service/MessageEventHandlerTests.java
+++ b/src/test/java/se/sundsvall/messaging/service/MessageEventHandlerTests.java
@@ -44,7 +44,7 @@ class MessageEventHandlerTests {
         messageEventHandler.handleIncomingMessageEvent(event);
 
         verify(mockDbIntegration, times(1)).getMessageByDeliveryId(any(String.class));
-        verify(mockMessageService, times(1)).deliver(any(Message.class));
+        verify(mockMessageService, times(1)).sendMessage(any(Message.class));
     }
 
     @Test
@@ -56,6 +56,6 @@ class MessageEventHandlerTests {
             .withMessageStartingWith("Internal Server Error: Unable to send");
 
         verify(mockDbIntegration, times(1)).getMessageByDeliveryId(any(String.class));
-        verify(mockMessageService, never()).deliver(any(Message.class));
+        verify(mockMessageService, never()).sendMessage(any(Message.class));
     }
 }


### PR DESCRIPTION
Fixes a bug with async `/message` delivery with a refactoring, because of a bug that short-circuited the async message routing by skipping the step where a message is processed and re-routed to e-mail or SMS