### PR TITLE
UF-6374 - DigitalMailSender support-info relaxation

### DIFF
--- a/src/integration-test/resources/openapi.yml
+++ b/src/integration-test/resources/openapi.yml
@@ -54,8 +54,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "502":
+          description: Bad Gateway
           content:
             application/json:
               schema:
@@ -63,8 +63,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "502":
-          description: Bad Gateway
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -116,8 +116,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "502":
+          description: Bad Gateway
           content:
             application/json:
               schema:
@@ -125,8 +125,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "502":
-          description: Bad Gateway
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -178,8 +178,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "502":
+          description: Bad Gateway
           content:
             application/json:
               schema:
@@ -187,8 +187,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "502":
-          description: Bad Gateway
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -240,8 +240,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "502":
+          description: Bad Gateway
           content:
             application/json:
               schema:
@@ -249,8 +249,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "502":
-          description: Bad Gateway
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -302,8 +302,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "502":
+          description: Bad Gateway
           content:
             application/json:
               schema:
@@ -311,8 +311,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "502":
-          description: Bad Gateway
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -364,8 +364,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "502":
+          description: Bad Gateway
           content:
             application/json:
               schema:
@@ -373,8 +373,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "502":
-          description: Bad Gateway
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -426,8 +426,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "502":
+          description: Bad Gateway
           content:
             application/json:
               schema:
@@ -435,8 +435,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "502":
-          description: Bad Gateway
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -488,8 +488,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "502":
+          description: Bad Gateway
           content:
             application/json:
               schema:
@@ -497,8 +497,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "502":
-          description: Bad Gateway
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -550,8 +550,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "502":
+          description: Bad Gateway
           content:
             application/json:
               schema:
@@ -559,8 +559,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "502":
-          description: Bad Gateway
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -946,11 +946,11 @@ components:
     StatusType:
       type: object
       properties:
+        reasonPhrase:
+          type: string
         statusCode:
           type: integer
           format: int32
-        reasonPhrase:
-          type: string
     DeliveryResult:
       type: object
       properties:
@@ -1235,7 +1235,7 @@ components:
         content:
           type: string
           description: Content (BASE64-encoded)
-      description: Attachments
+      description: Attachment
     LetterParty:
       required:
       - partyIds
@@ -1302,20 +1302,22 @@ components:
       description: Sender
     LetterSenderSupportInfo:
       required:
-      - emailAddress
-      - phoneNumber
       - text
-      - url
       type: object
       properties:
         text:
           type: string
+          description: Text
         emailAddress:
           type: string
+          description: E-mail address
         phoneNumber:
           type: string
+          description: Phone number
         url:
           type: string
+          description: URL
+      description: Support info
     EmailAttachment:
       required:
       - content
@@ -1409,7 +1411,7 @@ components:
         filename:
           type: string
           description: Filename
-      description: Attachments
+      description: Attachment
     DigitalMailParty:
       required:
       - partyIds
@@ -1468,20 +1470,23 @@ components:
       description: Sender
     DigitalMailSenderSupportInfo:
       required:
-      - emailAddress
-      - phoneNumber
       - text
       - url
       type: object
       properties:
         text:
           type: string
+          description: Text
         emailAddress:
           type: string
+          description: E-mail address
         phoneNumber:
           type: string
+          description: Phone number
         url:
           type: string
+          description: URL
+      description: Support info
     Details:
       required:
       - accountNumber

--- a/src/integration-test/resources/openapi.yml
+++ b/src/integration-test/resources/openapi.yml
@@ -45,8 +45,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageResult'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -63,8 +63,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/json:
               schema:
@@ -107,8 +107,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageResult'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -125,8 +125,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/json:
               schema:
@@ -169,8 +169,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageResult'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -187,8 +187,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/json:
               schema:
@@ -231,8 +231,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageResult'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -249,8 +249,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/json:
               schema:
@@ -293,8 +293,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageBatchResult'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -311,8 +311,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/json:
               schema:
@@ -355,8 +355,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageBatchResult'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -373,8 +373,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/json:
               schema:
@@ -417,8 +417,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageResult'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -435,8 +435,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/json:
               schema:
@@ -479,8 +479,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageBatchResult'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -497,8 +497,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/json:
               schema:
@@ -541,8 +541,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/MessageResult'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/json:
               schema:
@@ -559,8 +559,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/json:
               schema:
@@ -1471,7 +1471,6 @@ components:
     DigitalMailSenderSupportInfo:
       required:
       - text
-      - url
       type: object
       properties:
         text:

--- a/src/main/java/se/sundsvall/messaging/api/model/request/DigitalMailRequest.java
+++ b/src/main/java/se/sundsvall/messaging/api/model/request/DigitalMailRequest.java
@@ -69,26 +69,28 @@ public record DigitalMailRequest(
 
         @With
         @Builder(setterPrefix = "with")
-        @Schema(name = "DigitalMailSenderSupportInfo")
+        @Schema(name = "DigitalMailSenderSupportInfo", description = "Support info")
         public record SupportInfo(
 
             @NotBlank
+            @Schema(description = "Text", requiredMode = REQUIRED)
             String text,
 
             @jakarta.validation.constraints.Email
-            @NotBlank
+            @Schema(description = "E-mail address")
             String emailAddress,
 
-            @NotBlank
+            @Schema(description = "Phone number")
             String phoneNumber,
 
             @NotBlank
+            @Schema(description = "URL")
             String url) { }
     }
 
     @With
     @Builder(setterPrefix = "with")
-    @Schema(name = "DigitalMailAttachment")
+    @Schema(name = "DigitalMailAttachment", description = "Attachment")
     public record Attachment(
 
         @OneOf("application/pdf")

--- a/src/main/java/se/sundsvall/messaging/api/model/request/DigitalMailRequest.java
+++ b/src/main/java/se/sundsvall/messaging/api/model/request/DigitalMailRequest.java
@@ -83,7 +83,6 @@ public record DigitalMailRequest(
             @Schema(description = "Phone number")
             String phoneNumber,
 
-            @NotBlank
             @Schema(description = "URL")
             String url) { }
     }

--- a/src/main/java/se/sundsvall/messaging/api/model/request/LetterRequest.java
+++ b/src/main/java/se/sundsvall/messaging/api/model/request/LetterRequest.java
@@ -78,26 +78,27 @@ public record LetterRequest(
 
         @With
         @Builder(setterPrefix = "with")
-        @Schema(name = "LetterSenderSupportInfo")
+        @Schema(name = "LetterSenderSupportInfo", description = "Support info")
         public record SupportInfo(
 
             @NotBlank
+            @Schema(description = "Text", requiredMode = REQUIRED)
             String text,
 
             @jakarta.validation.constraints.Email
-            @NotBlank
+            @Schema(description = "E-mail address")
             String emailAddress,
 
-            @NotBlank
+            @Schema(description = "Phone number")
             String phoneNumber,
 
-            @NotBlank
+            @Schema(description = "URL")
             String url) { }
     }
 
     @With
     @Builder(setterPrefix = "with")
-    @Schema(name = "LetterAttachment")
+    @Schema(name = "LetterAttachment", description = "Attachment")
     public record Attachment(
 
         @NotNull

--- a/src/test/java/se/sundsvall/messaging/api/model/request/DigitalMailRequestConstraintValidationTests.java
+++ b/src/test/java/se/sundsvall/messaging/api/model/request/DigitalMailRequestConstraintValidationTests.java
@@ -92,24 +92,6 @@ class DigitalMailRequestConstraintValidationTests {
     }
 
     @Test
-    void shouldFailWithSupportInfoWithNullUrl() {
-        var sender = validRequest.sender()
-            .withSupportInfo(validRequest.sender().supportInfo().withUrl(null));
-
-        assertThat(validRequest.withSender(sender))
-            .hasSingleConstraintViolation("sender.supportInfo.url", "must not be blank");
-    }
-
-    @Test
-    void shouldFailWithSupportInfoWithBlankUrl() {
-        var sender = validRequest.sender()
-            .withSupportInfo(validRequest.sender().supportInfo().withUrl(" "));
-
-        assertThat(validRequest.withSender(sender))
-            .hasSingleConstraintViolation("sender.supportInfo.url", "must not be blank");
-    }
-
-    @Test
     void shouldFailWithNullContentType() {
         assertThat(validRequest.withContentType(null))
             .hasConstraintViolation("contentType", "must not be blank")

--- a/src/test/java/se/sundsvall/messaging/api/model/request/DigitalMailRequestConstraintValidationTests.java
+++ b/src/test/java/se/sundsvall/messaging/api/model/request/DigitalMailRequestConstraintValidationTests.java
@@ -83,49 +83,12 @@ class DigitalMailRequestConstraintValidationTests {
     }
 
     @Test
-    void shouldFailWithSupportInfoWithNullEmailAddress() {
-        var sender = validRequest.sender()
-            .withSupportInfo(validRequest.sender().supportInfo().withEmailAddress(null));
-
-        assertThat(validRequest.withSender(sender))
-            .hasSingleConstraintViolation("sender.supportInfo.emailAddress", "must not be blank");
-    }
-
-    @Test
-    void shouldFailWithSupportInfoWithBlankEmailAddress() {
-        var sender = validRequest.sender()
-            .withSupportInfo(validRequest.sender().supportInfo().withEmailAddress(" "));
-
-        assertThat(validRequest.withSender(sender))
-            .hasConstraintViolation("sender.supportInfo.emailAddress", "must not be blank")
-            .hasConstraintViolation("sender.supportInfo.emailAddress", "must be a well-formed email address");
-    }
-
-    @Test
     void shouldFailWithSupportInfoWithInvalidEmailAddress() {
         var sender = validRequest.sender()
             .withSupportInfo(validRequest.sender().supportInfo().withEmailAddress("not-an-email-address"));
 
         assertThat(validRequest.withSender(sender))
             .hasSingleConstraintViolation("sender.supportInfo.emailAddress", "must be a well-formed email address");
-    }
-
-    @Test
-    void shouldFailWithSupportInfoWithNullPhoneNumber() {
-        var sender = validRequest.sender()
-            .withSupportInfo(validRequest.sender().supportInfo().withPhoneNumber(null));
-
-        assertThat(validRequest.withSender(sender))
-            .hasSingleConstraintViolation("sender.supportInfo.phoneNumber", "must not be blank");
-    }
-
-    @Test
-    void shouldFailWithSupportInfoWithBlankPhoneNumber() {
-        var sender = validRequest.sender()
-            .withSupportInfo(validRequest.sender().supportInfo().withPhoneNumber(" "));
-
-        assertThat(validRequest.withSender(sender))
-            .hasSingleConstraintViolation("sender.supportInfo.phoneNumber", "must not be blank");
     }
 
     @Test

--- a/src/test/java/se/sundsvall/messaging/api/model/request/LetterRequestConstraintValidationTests.java
+++ b/src/test/java/se/sundsvall/messaging/api/model/request/LetterRequestConstraintValidationTests.java
@@ -83,67 +83,12 @@ class LetterRequestConstraintValidationTests {
     }
 
     @Test
-    void shouldFailWithSendWithSupportInfoWithNullEmailAddress() {
-        var sender = validRequest.sender()
-            .withSupportInfo(validRequest.sender().supportInfo().withEmailAddress(null));
-
-        assertThat(validRequest.withSender(sender))
-            .hasSingleConstraintViolation("sender.supportInfo.emailAddress", "must not be blank");
-    }
-
-    @Test
-    void shouldFailWithSendWithSupportInfoWithBlankEmailAddress() {
-        var sender = validRequest.sender()
-            .withSupportInfo(validRequest.sender().supportInfo().withEmailAddress(" "));
-
-        assertThat(validRequest.withSender(sender))
-            .hasConstraintViolation("sender.supportInfo.emailAddress", "must not be blank")
-            .hasConstraintViolation("sender.supportInfo.emailAddress", "must be a well-formed email address");
-    }
-
-    @Test
     void shouldFailWithSendWithSupportInfoWithInvalidEmailAddress() {
         var sender = validRequest.sender()
             .withSupportInfo(validRequest.sender().supportInfo().withEmailAddress("not-an-email-address"));
 
         assertThat(validRequest.withSender(sender))
             .hasSingleConstraintViolation("sender.supportInfo.emailAddress", "must be a well-formed email address");
-    }
-
-    @Test
-    void shouldFailWithSendWithSupportInfoWithNullPhoneNumber() {
-        var sender = validRequest.sender()
-            .withSupportInfo(validRequest.sender().supportInfo().withPhoneNumber(null));
-
-        assertThat(validRequest.withSender(sender))
-            .hasSingleConstraintViolation("sender.supportInfo.phoneNumber", "must not be blank");
-    }
-
-    @Test
-    void shouldFailWithSendWithSupportInfoWithBlankPhoneNumber() {
-        var sender = validRequest.sender()
-            .withSupportInfo(validRequest.sender().supportInfo().withPhoneNumber(" "));
-
-        assertThat(validRequest.withSender(sender))
-            .hasSingleConstraintViolation("sender.supportInfo.phoneNumber", "must not be blank");
-    }
-
-    @Test
-    void shouldFailWithSendWithSupportInfoWithNullUrl() {
-        var sender = validRequest.sender()
-            .withSupportInfo(validRequest.sender().supportInfo().withUrl(null));
-
-        assertThat(validRequest.withSender(sender))
-            .hasSingleConstraintViolation("sender.supportInfo.url", "must not be blank");
-    }
-
-    @Test
-    void shouldFailWithSendWithSupportInfoWithBlankUrl() {
-        var sender = validRequest.sender()
-            .withSupportInfo(validRequest.sender().supportInfo().withUrl(" "));
-
-        assertThat(validRequest.withSender(sender))
-            .hasSingleConstraintViolation("sender.supportInfo.url", "must not be blank");
     }
 
     @Test


### PR DESCRIPTION
Makes everything but "text" non-required in the support-info used when sending digital mail