### PR TITLE
UF-15792: Fixed oep instance value bug

### DIFF
--- a/src/integration-test/resources/WebMessageIT/__files/test1_successfulRequest/mappings/oep-integrator-createWebmessage.json
+++ b/src/integration-test/resources/WebMessageIT/__files/test1_successfulRequest/mappings/oep-integrator-createWebmessage.json
@@ -6,7 +6,7 @@
 			}
 		},
 		"method": "POST",
-		"urlPath": "/oep-integrator/2281/internal/webmessages"
+		"urlPath": "/oep-integrator/2281/INTERNAL/webmessages"
 	},
 	"response": {
 		"headers": {

--- a/src/integration-test/resources/WebMessageIT/__files/test1_successfulRequest/request.json
+++ b/src/integration-test/resources/WebMessageIT/__files/test1_successfulRequest/request.json
@@ -6,7 +6,7 @@
 			"mimeType": "text/plain"
 		}
 	],
-	"oepInstance": "internal",
+	"oepInstance": "INTERNAL",
 	"message": "This is a test message",
 	"party": {
 		"partyId": "f427952b-247c-4d3b-b081-675a467b3619"

--- a/src/integration-test/resources/WebMessageIT/__files/test2_internalServerErrorFromWebMessageSender/mappings/oep-integrator-createWebmessage.json
+++ b/src/integration-test/resources/WebMessageIT/__files/test2_internalServerErrorFromWebMessageSender/mappings/oep-integrator-createWebmessage.json
@@ -6,7 +6,7 @@
 			}
 		},
 		"method": "POST",
-		"urlPath": "/oep-integrator/2281/external/webmessages"
+		"urlPath": "/oep-integrator/2281/EXTERNAL/webmessages"
 	},
 	"response": {
 		"headers": {

--- a/src/integration-test/resources/openapi.yml
+++ b/src/integration-test/resources/openapi.yml
@@ -1547,10 +1547,10 @@ components:
           type: string
           description: Determines if the message should be added to the internal or
             external OeP instance
-          example: internal
+          example: INTERNAL
           enum:
-            - internal
-            - external
+            - INTERNAL
+            - EXTERNAL
         attachments:
           maxItems: 10
           minItems: 0

--- a/src/main/java/se/sundsvall/messaging/Constants.java
+++ b/src/main/java/se/sundsvall/messaging/Constants.java
@@ -26,6 +26,10 @@ public final class Constants {
 
 	public static final String X_ORIGIN_HEADER_KEY = "x-origin";
 
+	public static final String OEP_INSTANCE_EXTERNAL = "EXTERNAL";
+
+	public static final String OEP_INSTANCE_INTERNAL = "INTERNAL";
+
 	private Constants() {}
 
 }

--- a/src/main/java/se/sundsvall/messaging/api/model/request/WebMessageRequest.java
+++ b/src/main/java/se/sundsvall/messaging/api/model/request/WebMessageRequest.java
@@ -2,6 +2,8 @@ package se.sundsvall.messaging.api.model.request;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+import static se.sundsvall.messaging.Constants.OEP_INSTANCE_EXTERNAL;
+import static se.sundsvall.messaging.Constants.OEP_INSTANCE_INTERNAL;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -36,8 +38,8 @@ public record WebMessageRequest(
 	@Schema(description = "Issuer of request", example = "user123", hidden = true) @JsonIgnore String issuer,
 
 	@Schema(description = "Determines if the message should be added to the internal or external OeP instance", allowableValues = {
-		"internal", "external"
-	}, example = "internal") @ValidInstance(nullable = true) String oepInstance,
+		OEP_INSTANCE_INTERNAL, OEP_INSTANCE_EXTERNAL
+	}, example = OEP_INSTANCE_INTERNAL) @ValidInstance(nullable = true) String oepInstance,
 
 	@Size(max = 10) @ArraySchema(schema = @Schema(implementation = Attachment.class), maxItems = 10) List<Attachment> attachments,
 

--- a/src/main/java/se/sundsvall/messaging/api/validation/ValidInstance.java
+++ b/src/main/java/se/sundsvall/messaging/api/validation/ValidInstance.java
@@ -17,7 +17,7 @@ import se.sundsvall.messaging.api.validation.impl.ValidInstanceConstraintValidat
 @Constraint(validatedBy = ValidInstanceConstraintValidator.class)
 public @interface ValidInstance {
 
-	String message() default "instance must be 'internal' or 'external'";
+	String message() default "instance must be 'INTERNAL' or 'EXTERNAL'";
 
 	boolean nullable();
 

--- a/src/main/java/se/sundsvall/messaging/api/validation/impl/ValidInstanceConstraintValidator.java
+++ b/src/main/java/se/sundsvall/messaging/api/validation/impl/ValidInstanceConstraintValidator.java
@@ -1,6 +1,8 @@
 package se.sundsvall.messaging.api.validation.impl;
 
 import static java.util.Objects.isNull;
+import static se.sundsvall.messaging.Constants.OEP_INSTANCE_EXTERNAL;
+import static se.sundsvall.messaging.Constants.OEP_INSTANCE_INTERNAL;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
@@ -24,7 +26,7 @@ public class ValidInstanceConstraintValidator implements ConstraintValidator<Val
 		if (isNull(value)) {
 			return nullable;
 		}
-		return "internal".equalsIgnoreCase(value) || "external".equalsIgnoreCase(value);
+		return OEP_INSTANCE_INTERNAL.equals(value) || OEP_INSTANCE_EXTERNAL.equals(value);
 	}
 
 }

--- a/src/main/java/se/sundsvall/messaging/service/mapper/DtoMapper.java
+++ b/src/main/java/se/sundsvall/messaging/service/mapper/DtoMapper.java
@@ -1,6 +1,7 @@
 package se.sundsvall.messaging.service.mapper;
 
 import static java.util.Optional.ofNullable;
+import static se.sundsvall.messaging.Constants.OEP_INSTANCE_EXTERNAL;
 
 import java.util.Map;
 import java.util.Optional;
@@ -156,7 +157,7 @@ public class DtoMapper {
 				.orElse(null))
 			.withMessage(request.message())
 			.withOepInstance(Optional.ofNullable(request.oepInstance())
-				.orElse("external"))
+				.orElse(OEP_INSTANCE_EXTERNAL))
 			.withSendAsOwner(request.sendAsOwner())
 			.withAttachments(ofNullable(request.attachments())
 				.map(attachments -> attachments.stream()

--- a/src/test/java/se/sundsvall/messaging/TestDataFactory.java
+++ b/src/test/java/se/sundsvall/messaging/TestDataFactory.java
@@ -209,7 +209,6 @@ public final class TestDataFactory {
 				.withExternalReferences(List.of(createExternalReference()))
 				.build())
 			.withMessage("someMessage")
-			.withOepInstance("internal")
 			.withAttachments(List.of(
 				WebMessageRequest.Attachment.builder()
 					.withFileName("someFileName")

--- a/src/test/java/se/sundsvall/messaging/api/MessageResourceWebMessageFailureTest.java
+++ b/src/test/java/se/sundsvall/messaging/api/MessageResourceWebMessageFailureTest.java
@@ -171,7 +171,7 @@ class MessageResourceWebMessageFailureTest {
 
 	@ParameterizedTest
 	@ValueSource(strings = {
-		"", " ", "invalid"
+		"", " ", "invalid", "internal", "external", "iNTERNAL", "eXTERNAL"
 	})
 	void shouldFailWithInvalidOepInstance(String oepInstance) {
 		// Arrange
@@ -193,7 +193,7 @@ class MessageResourceWebMessageFailureTest {
 		assertThat(response).isNotNull();
 		assertThat(response.getViolations())
 			.extracting(Violation::getField, Violation::getMessage)
-			.containsExactly(tuple("oepInstance", "instance must be 'internal' or 'external'"));
+			.containsExactly(tuple("oepInstance", "instance must be 'INTERNAL' or 'EXTERNAL'"));
 
 		verifyNoInteractions(mockMessageService, mockEventDispatcher);
 	}

--- a/src/test/java/se/sundsvall/messaging/api/MessageResourceWebMessageTest.java
+++ b/src/test/java/se/sundsvall/messaging/api/MessageResourceWebMessageTest.java
@@ -65,7 +65,7 @@ class MessageResourceWebMessageTest {
 	private WebTestClient webTestClient;
 
 	private static Stream<String> oepInstances() {
-		return Stream.of(null, "external", "internal", "eXtErNaL", "interNaL");
+		return Stream.of(null, "EXTERNAL", "INTERNAL");
 	}
 
 	private static Stream<List<Attachment>> attachments() {

--- a/src/test/java/se/sundsvall/messaging/api/validation/impl/ValidInstanceConstraintValidatorTest.java
+++ b/src/test/java/se/sundsvall/messaging/api/validation/impl/ValidInstanceConstraintValidatorTest.java
@@ -25,7 +25,7 @@ class ValidInstanceConstraintValidatorTest {
 
 	@ParameterizedTest
 	@ValueSource(strings = {
-		"internal", "external"
+		"INTERNAL", "EXTERNAL"
 	})
 	void validInstance(final String oepInstance) {
 		validator.initialize(mockAnnotation);
@@ -39,7 +39,7 @@ class ValidInstanceConstraintValidatorTest {
 	@ParameterizedTest
 	@NullSource
 	@ValueSource(strings = {
-		"not-valid", "", " "
+		"not-valid", "", " ", "internal", "external", "INTERNAl", "eXTERNAL"
 	})
 	void invalidOepInstance(final String oepInstance) {
 		validator.initialize(mockAnnotation);


### PR DESCRIPTION
- Aligned valid value in incoming messaging request to be equal to the values that the oep integrator service allows

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [x] Yes (As v7.0 is still in test phase, the decision is to replace existing faulty definition with the correct one)
- [ ] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
