### PR TITLE
UF-15879 Party Integration Fix.

### DIFF
--- a/src/main/java/se/sundsvall/messaging/service/HistoryService.java
+++ b/src/main/java/se/sundsvall/messaging/service/HistoryService.java
@@ -179,7 +179,9 @@ public class HistoryService {
 
 	List<UserMessage.Recipient> createRecipients(final String municipalityId, final List<HistoryEntity> histories) {
 		return histories.stream().map(history -> {
-			var legalId = partyIntegration.getLegalIdByPartyId(municipalityId, history.getPartyId());
+			var legalId = Optional.ofNullable(history.getPartyId())
+				.map(party -> partyIntegration.getLegalIdByPartyId(municipalityId, party))
+				.orElse(null);
 			var messageType = history.getMessageType().toString();
 			var status = history.getStatus().name();
 			return new UserMessage.Recipient(legalId, messageType, status);


### PR DESCRIPTION
Handles the case where party id is null in the history table. Previously this was causing issues because we were calling party with a null party id. Instead this will just skip the party call and leave the person id blank

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [ ] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
