### PR TITLE
HYDRAN-2338: Propagate MDC to application event listeners

### DIFF
--- a/src/main/java/se/sundsvall/messaging/configuration/EventPublisherConfiguration.java
+++ b/src/main/java/se/sundsvall/messaging/configuration/EventPublisherConfiguration.java
@@ -5,14 +5,22 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.ApplicationEventMulticaster;
 import org.springframework.context.event.SimpleApplicationEventMulticaster;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.core.task.TaskDecorator;
 
 @Configuration
 class EventPublisherConfiguration {
 
+	/**
+	 * The event multicaster runs on its own executor, which Spring Boot's task execution auto-configuration never
+	 * touches. The MDC/Identifier-propagating {@link TaskDecorator} provided by dept44 therefore has to be applied to it
+	 * explicitly, or events lose the request id and the sender identity of the request that published them.
+	 */
 	@Bean(name = "applicationEventMulticaster")
-	ApplicationEventMulticaster simpleApplicationEventMulticaster() {
+	ApplicationEventMulticaster simpleApplicationEventMulticaster(final TaskDecorator taskDecorator) {
 		var eventMulticaster = new SimpleApplicationEventMulticaster();
-		eventMulticaster.setTaskExecutor(new SimpleAsyncTaskExecutor());
+		var taskExecutor = new SimpleAsyncTaskExecutor();
+		taskExecutor.setTaskDecorator(taskDecorator);
+		eventMulticaster.setTaskExecutor(taskExecutor);
 		return eventMulticaster;
 	}
 }


### PR DESCRIPTION
## What

The event multicaster ran on a bare `SimpleAsyncTaskExecutor`, so every `@Async` event listener lost the request id and the sender identity of the request that published the event.

The multicaster has its own executor, which Spring Boot's task execution auto-configuration never touches, so the MDC/`Identifier`-propagating `TaskDecorator` that dept44 8.0.8+ auto-configures has to be applied to it explicitly.

The decorator is **injected** rather than instantiated, so the `dept44.async.mdc.enabled` switch and any custom decorator bean still apply.

## Verification

`mvn clean verify` green (1285 unit tests + 69 ITs). The ITs boot the full application context, so a missing `TaskDecorator` bean would have failed startup rather than passing silently.

## Related

Same cleanup as casemanagement [#287](https://github.com/Sundsvallskommun/api-service-casemanagement/pull/287), case-status [#260](https://github.com/Sundsvallskommun/api-service-case-status/pull/260) and postportalservice [#106](https://github.com/Sundsvallskommun/api-service-postportalservice/pull/106).