### PR TITLE
hydran-xyz-sonar-issues

### DIFF
--- a/src/main/java/se/sundsvall/messaging/integration/db/entity/HistoryEntity.java
+++ b/src/main/java/se/sundsvall/messaging/integration/db/entity/HistoryEntity.java
@@ -13,6 +13,7 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -149,7 +150,7 @@ public class HistoryEntity {
 
 	@PrePersist
 	void prePersist() {
-		createdAt = LocalDateTime.now();
+		createdAt = LocalDateTime.now(ZoneId.systemDefault());
 
 		destinationAddressJson = toJson(destinationAddress);
 	}

--- a/src/main/java/se/sundsvall/messaging/integration/db/entity/MessageEntity.java
+++ b/src/main/java/se/sundsvall/messaging/integration/db/entity/MessageEntity.java
@@ -12,6 +12,7 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -124,7 +125,7 @@ public class MessageEntity {
 
 	@PrePersist
 	void prePersist() {
-		createdAt = LocalDateTime.now();
+		createdAt = LocalDateTime.now(ZoneId.systemDefault());
 
 		destinationAddressJson = toJson(destinationAddress);
 	}

--- a/src/main/java/se/sundsvall/messaging/integration/db/mapper/HistoryMapper.java
+++ b/src/main/java/se/sundsvall/messaging/integration/db/mapper/HistoryMapper.java
@@ -2,6 +2,7 @@ package se.sundsvall.messaging.integration.db.mapper;
 
 import com.google.gson.JsonParser;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import org.springframework.data.domain.Page;
 import se.sundsvall.dept44.models.api.paging.PagingAndSortingMetaData;
@@ -53,7 +54,7 @@ public final class HistoryMapper {
 			.withOrigin(actualMessage.origin())
 			.withIssuer(actualMessage.issuer())
 			.withDepartment(toDepartment(actualMessage.content()))
-			.withCreatedAt(LocalDateTime.now())
+			.withCreatedAt(LocalDateTime.now(ZoneId.systemDefault()))
 			.withMunicipalityId(actualMessage.municipalityId())
 			.withDestinationAddress(actualMessage.address())
 			.withOrganizationNumber(actualMessage.organizationNumber())

--- a/src/main/java/se/sundsvall/messaging/service/HistoryService.java
+++ b/src/main/java/se/sundsvall/messaging/service/HistoryService.java
@@ -5,6 +5,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -124,7 +125,7 @@ public class HistoryService {
 	}
 
 	public UserBatches getUserBatches(final String municipalityId, final String issuer, final Integer page, final Integer limit) {
-		final var thirtyDaysAgo = LocalDate.now().minusDays(30).atStartOfDay();
+		final var thirtyDaysAgo = LocalDate.now(ZoneId.systemDefault()).minusDays(30).atStartOfDay();
 		final var batches = dbIntegration.getBatchHistoryMessagesForUser(municipalityId, issuer, thirtyDaysAgo).stream() // Fetch batchprojections for all messages sent the 30 last day for issuer
 			.collect(groupingBy(BatchHistoryProjection::getBatchId)).entrySet().stream() // Group result by batch id and stream result (Map<batchId, List<BatchHistoryProjection>>)
 			.map(entry -> createBatch(municipalityId, entry)) // To map each entry to a Batch object
@@ -156,7 +157,7 @@ public class HistoryService {
 	}
 
 	public UserMessages getUserMessages(final String municipalityId, final String userId, String batchId, final Integer page, final Integer limit) {
-		final var thirtyDaysAgo = LocalDateTime.now().minusDays(30);
+		final var thirtyDaysAgo = LocalDateTime.now(ZoneId.systemDefault()).minusDays(30);
 		final var pageRequest = PageRequest.of(page - 1, limit);
 		final var messageIdPage = isNull(batchId) ? dbIntegration.getUniqueMessageIds(municipalityId, userId, thirtyDaysAgo, pageRequest)
 			: dbIntegration.getUniqueMessageIds(municipalityId, batchId, userId, thirtyDaysAgo, pageRequest);


### PR DESCRIPTION
Fixes the open **java.time** SonarCloud issues in this service (`java:S8688` × 5).

> Explicitly specify the time zone by passing a ZoneId or a Clock to the `.now()` method.

Every no-arg `java.time` `.now()` call in `src/main` now passes `ZoneId.systemDefault()` explicitly, including statically imported bare `now()` calls. Behaviour unchanged, and this matches the convention already dominant across the fleet.

### Verification
`mvn clean verify` — all tests green, JaCoCo coverage gate passed.

### Note on the SonarCloud quality gate
This PR may trip `new_duplicated_lines_density`. The changed lines often sit inside `@PrePersist`/`@PreUpdate` timestamp boilerplate that is near-identical across entity classes, and a PR's denominator is only the changed lines — so a few lines inside pre-existing duplicated blocks can exceed the 3% threshold. No code defect and no behaviour change; needs a reviewer override.
